### PR TITLE
Fix variable used in one form of filtering

### DIFF
--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -657,9 +657,9 @@ if (is.null(params$filtering_grouping_var)){
   }
 }else{
   if (is.null(params$filtering_min_proportion)){
-    filtering_string <- paste0(filtering_string, ' in at least the number of samples corresponding to the smallest group size defined by the grouping variable "', contrasts$variable[1], '".')
+    filtering_string <- paste0(filtering_string, ' in at least the number of samples corresponding to the smallest group size defined by the grouping variable "', params$filtering_grouping_var, '".')
   }else{
-    filtering_string <- paste0(filtering_string, ' in at least a proportion of ', params$filtering_min_proportion, ' of the number of samples corresponding to the smallest group size defined by the grouping variable"', contrasts$variable[1], '".')
+    filtering_string <- paste0(filtering_string, ' in at least a proportion of ', params$filtering_min_proportion, ' of the number of samples corresponding to the smallest group size defined by the grouping variable"', params$filtering_grouping_var, '".')
   }
 }
 cat(filtering_string)


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

A trivial fix to address an error I made in reporting. Users can specify a variable to be used in deriving minimum sample numbers for a threshold, but this variable must be supplied directly and is not derived from the contrasts (which was what I used incorrectly when composing some of the text).

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
