### PR TITLE
Pre-release plotting fixes

### DIFF
--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -41,6 +41,8 @@ params:
   exploratory_clustering_method: null
   exploratory_cor_method: null
   exploratory_whisker_distance: null
+  exploratory_mad_threshold: null
+  exploratory_main_variable: null
   versions_file: null                                         # e.g 17_software_versions.yml
   logo: null
   css: null
@@ -240,10 +242,6 @@ informative_variables <- unique(c(contrasts$variable, chooseGroupingVariables(ob
 # Remove any informative variables that group observations the same way
 informative_variables <- informative_variables[ ! duplicated(lapply(structure(informative_variables, names= informative_variables), function(x) as.numeric(factor(observations[[x]], levels=unique(observations[[x]])))))]
 
-# Pick the first variable used in contrasts for coloring purposes
-main_grouping_variable <- contrasts$variable[1]
-groupColorScale <- makeColorScale(length(unique(observations[[main_grouping_variable]])), palette = "Set1")
-
 assay_files <- list(
   raw = file.path(params$input_dir, params$raw_matrix),
   normalised = file.path(params$input_dir,params$normalised_matrix),
@@ -262,6 +260,36 @@ assay_data <- lapply(assay_files, function(x) {
 
 # Now we can rename the observations rows using the title field
 rownames(observations) <- observations[[observations_name_col]]
+
+# Run PCA early so we can understand how important each variable is
+
+pca_datas <- lapply(names(assay_data), function(assay_type){
+  if (assay_type == 'variance_stabilised'){
+    compilePCAData(assay_data[[assay_type]])
+  }else{
+    compilePCAData(log2(assay_data[[assay_type]]+1))
+  }
+})
+names(pca_datas) <- names(assay_data)
+
+pca_vs_meta <- anova_pca_metadata(pca_datas[['variance_stabilised']]$coords, observations[,informative_variables], pca_datas[['variance_stabilised']]$percentVar)
+
+# Show the variable with the tightest PC associations first
+informative_variables <- rownames(pca_vs_meta)[order(pca_vs_meta[,1])]
+
+# Pick the variable used for coloring purposes etc
+if (params$exploratory_main_variable == 'contrasts'){
+  main_grouping_variable <- contrasts$variable[1]
+}else if (params$exploratory_main_variable == 'auto_pca'){
+  main_grouping_variable <- informative_variables[1]
+}else{
+  if (! params$exploratory_main_variable %in% colnames(observations)){
+    stop(paste('Invalid main variable specified: ', params$exploratory_main_variable))
+  }
+  main_grouping_variable <- params$exploratory_main_variable
+}
+
+groupColorScale <- makeColorScale(length(unique(observations[[main_grouping_variable]])), palette = "Set1")
 ```
 
 <!-- Read the differential results.
@@ -434,7 +462,7 @@ plotly_densityplot(
 ```
 
 ```{r, echo=FALSE, results='asis'}
-cat(paste0("\n### ", params$observations_type, " relationships\n"))
+cat(paste0("\n### ", ucfirst(params$observations_type), " relationships\n"))
 ```
 
 #### Principal components plots {.tabset}
@@ -442,20 +470,6 @@ cat(paste0("\n### ", params$observations_type, " relationships\n"))
 Principal components analysis was conducted based on the `r params$exploratory_n_features` most variable `r params$features_type`s. Each component was annotated with its percent contribution to variance. 
 
 ```{r, echo=FALSE, results='asis'}
-pca_datas <- lapply(names(assay_data), function(assay_type){
-  if (assay_type == 'variance_stabilised'){
-    compilePCAData(assay_data[[assay_type]])
-  }else{
-    compilePCAData(log2(assay_data[[assay_type]]+1))
-  }
-})
-names(pca_datas) <- names(assay_data)
-
-pca_vs_meta <- anova_pca_metadata(pca_datas[['variance_stabilised']]$coords, observations[,informative_variables], pca_datas[['variance_stabilised']]$percentVar)
-
-# Show the variable with the tightest PC associations first
-informative_variables <- rownames(pca_vs_meta)[order(pca_vs_meta[,1])]
-
 for (assay_type in rev(names(assay_data))){
   
   pca_data <- pca_datas[[assay_type]]
@@ -576,6 +590,48 @@ p <- clusteringDendrogram(
 # Defaults in shinyngs make the text in this plot a bit big for the report, so
 # scale it down a bit
 print(p, vp=grid::viewport(gp=grid::gpar(cex=0.7)))
+
+```
+
+### Outlier detection {.tabset}
+
+Outlier detection based on [median absolute deviation](https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf) was undertaken, the outlier scoring is plotted below.
+
+```{r, echo=FALSE, results='asis', warning=FALSE}
+
+for (iv in informative_variables){
+  cat(paste("\n####", iv, "\n"))
+  
+  plotdata <-
+  madScore(
+    matrix = assay_data[['variance_stabilised']],
+    sample_sheet = observations,
+    groupby = iv
+  )
+
+  mad_plot_args <- list(
+    x = plotdata$group,
+    y = plotdata$mad,
+    color = plotdata$outlier,
+    hline_thresholds = c("Outlier threshold" = params$exploratory_mad_threshold),
+    palette = makeColorScale(2, palette = "Set1"),
+    legend_title = "Outlier status",
+    labels = rownames(plotdata),
+    show_labels = TRUE,
+    xlab = "Sample group",
+    ylab = "MAD score"
+  )
+
+  print(htmltools::tagList(do.call("plotly_scatterplot", mad_plot_args)))
+
+  outliers <- rownames(plotdata)[plotdata$outlier]
+
+  if (length(outliers) == 0){
+    cat(paste0("No outlying samples were detected in groups defined by ", iv,".\n"))
+  }else{
+    cat(paste0(length(outliers), ' possible outliers were detected in groups defined by ', iv ,': ', paste(outliers, collapse=', '), "\n"))
+  }
+}
 
 ```
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -435,7 +435,7 @@ The following plots show the abundance value distributions of input matrices. A 
 
 ```{r, echo=FALSE, results='asis', fig.height=8}
 
-p <- ggplot_boxplot(
+ggplot_boxplot(
   assay_data, 
   experiment = observations, 
   colorby = main_grouping_variable, 
@@ -444,7 +444,6 @@ p <- ggplot_boxplot(
   whisker_distance = params$exploratory_whisker_distance,
   base_size=8
 )
-p
 ```
 
 Whiskers in the above boxplots show `r params$exploratory_whisker_distance` times the inter-quartile range.
@@ -599,7 +598,7 @@ Outlier detection based on [median absolute deviation](https://wiki.arrayserver.
 
 ```{r, echo=FALSE, results='asis', warning=FALSE}
 
-for (iv in informative_variables){
+lapply(informative_variables, function(iv){
   cat(paste("\n####", iv, "\n"))
   
   plotdata <-
@@ -631,7 +630,7 @@ for (iv in informative_variables){
   }else{
     cat(paste0(length(outliers), ' possible outliers were detected in groups defined by ', iv ,': ', paste(outliers, collapse=', '), "\n"))
   }
-}
+})
 
 ```
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -405,23 +405,25 @@ The following plots show the abundance value distributions of input matrices. A 
 ```
 #### Box plots
 
-```{r, echo=FALSE, results='asis'}
+```{r, echo=FALSE, results='asis', fig.height=8}
 
-ggplot_boxplot(
+p <- ggplot_boxplot(
   assay_data, 
   experiment = observations, 
   colorby = main_grouping_variable, 
   expressiontype = paste("count per", params$features_type), 
   palette = groupColorScale,
-  whisker_distance = params$exploratory_whisker_distance
+  whisker_distance = params$exploratory_whisker_distance,
+  base_size=8
 )
+p
 ```
 
 Whiskers in the above boxplots show `r params$exploratory_whisker_distance` times the inter-quartile range.
 
 #### Density plots
 
-```{r, echo=FALSE, results='asis'}
+```{r, echo=FALSE, results='asis', fig.height=8}
 plotly_densityplot(
   assay_data, 
   experiment = observations, 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -131,7 +131,8 @@ process {
             "--sample_id_col \"${params.observations_id_col}\"",
             "--feature_id_col \"${params.features_id_col}\"",
             "--assay_names raw,normalised,variance_stabilised",
-            "--final_assay variance_stabilised"
+            "--final_assay variance_stabilised",
+            "--outlier_mad_threshold ${params.exploratory_mad_threshold}"
         ].join(' ').trim() }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -144,7 +144,13 @@ process {
         ext.args = { [
             "--feature_id_col \"${params.features_id_col}\"",
             "--reference_level \"$meta.reference\"",
-            "--treatment_level \"$meta.target\""
+            "--treatment_level \"$meta.target\"",
+            "--fold_change_col \"${params.differential_fc_column}\"",
+            "--p_value_column \"${params.differential_qval_column}\"",
+            "--diff_feature_id_col \"${params.differential_feature_id_column}\"",
+            "--fold_change_threshold \"${params.differential_min_fold_change}\"",
+            "--p_value_threshold \"${params.differential_max_qval}\"",
+            "--unlog_foldchanges \"${params.differential_foldchanges_logged}\""
         ].join(' ').trim() }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -157,8 +157,8 @@ process {
     }
 
     withName: RMARKDOWNNOTEBOOK {
-        conda = "bioconda::r-shinyngs=1.5.0"
-        container = { "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.0--r42hdfd78af_0':'quay.io/biocontainers/r-shinyngs:1.5.0--r42hdfd78af_0' }" }
+        conda = "bioconda::r-shinyngs=1.5.3"
+        container = { "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.3--r42hdfd78af_0':'quay.io/biocontainers/r-shinyngs:1.5.3--r42hdfd78af_0' }" }
         publishDir = [
             path: { "${params.outdir}/${params.study_name}/report" },
             mode: params.publish_dir_mode,

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,7 @@ params {
     filtering_grouping_var     = null
 
     // Exploratory options
+    exploratory_main_variable      = 'auto_pca'
     exploratory_clustering_method  = "ward.D2"
     exploratory_cor_method         = "spearman"
     exploratory_n_features         = 500

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,6 +41,7 @@ params {
     exploratory_cor_method         = "spearman"
     exploratory_n_features         = 500
     exploratory_whisker_distance   = 1.5
+    exploratory_mad_threshold      = -5
   
     // Differential options
     differential_file_suffix         = ".deseq2.results.tsv" 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -215,7 +215,7 @@
                 "exploratory_main_variable": {
                     "type": "string",
                     "default": "auto_pca",
-                    "description": "How should the main grouping variable be selected?",
+                    "description": "How should the main grouping variable be selected? 'auto_pca', 'contrasts', or a valid column from observations",
                     "help_text": "Some plots are only generated once, with a single sample grouping, this option defines how that happens. It should be 'auto_pca' (variable selected from the sample sheet with most association with the first principal component), 'contrasts' (pick the variable associated with the first contrast), or a value specifying a specific column in the observations."
                 }
             },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -216,7 +216,7 @@
                     "type": "string",
                     "default": "auto_pca",
                     "description": "How should the main grouping variable be selected? 'auto_pca', 'contrasts', or a valid column name from the observations table.",
-                    "help_text": "Some plots are only generated once, with a single sample grouping, this option defines how that happens. It should be 'auto_pca' (variable selected from the sample sheet with most association with the first principal component), 'contrasts' (pick the variable associated with the first contrast), or a value specifying a specific column in the observations."
+                    "help_text": "Some plots are only generated once, with a single sample grouping, this option defines how that sample grouping is selected. It should be 'auto_pca' (variable selected from the sample sheet with the most association with the first principal component), 'contrasts' (pick the variable associated with the first contrast), or a value specifying a specific column in the observations."
                 }
             },
             "fa_icon": "fas fa-chart-area",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -149,7 +149,7 @@
                     "description": "Type of feature we have, often 'gene'"
                 }
             },
-            "required": ["features_id_col", "features_type", "features_name_col"]
+            "required": ["features_id_col", "features_name_col", "features_type"]
         },
         "filtering": {
             "title": "Filtering",
@@ -205,6 +205,12 @@
                     "type": "number",
                     "default": 1.5,
                     "description": "Length of the whiskers in boxplots as multiple of IQR. Defaults to 1.5."
+                },
+                "exploratory_mad_threshold": {
+                    "type": "integer",
+                    "default": -5,
+                    "help_text": "MAD = median absolute deviation. A threshold on this value is used to define observations (samples) as outliers, or not, in exploratory plots. Based on the definition at https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf. ",
+                    "description": "Threshold on MAD score for outlier identification"
                 }
             },
             "fa_icon": "fas fa-chart-area",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -215,7 +215,7 @@
                 "exploratory_main_variable": {
                     "type": "string",
                     "default": "auto_pca",
-                    "description": "How should the main grouping variable be selected? 'auto_pca', 'contrasts', or a valid column from observations",
+                    "description": "How should the main grouping variable be selected? 'auto_pca', 'contrasts', or a valid column name from the observations table.",
                     "help_text": "Some plots are only generated once, with a single sample grouping, this option defines how that happens. It should be 'auto_pca' (variable selected from the sample sheet with most association with the first principal component), 'contrasts' (pick the variable associated with the first contrast), or a value specifying a specific column in the observations."
                 }
             },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -211,10 +211,21 @@
                     "default": -5,
                     "help_text": "MAD = median absolute deviation. A threshold on this value is used to define observations (samples) as outliers, or not, in exploratory plots. Based on the definition at https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf. ",
                     "description": "Threshold on MAD score for outlier identification"
+                },
+                "exploratory_main_variable": {
+                    "type": "string",
+                    "default": "auto_pca",
+                    "description": "How should the main grouping variable be selected?",
+                    "help_text": "Some plots are only generated once, with a single sample grouping, this option defines how that happens. It should be 'auto_pca' (variable selected from the sample sheet with most association with the first principal component), 'contrasts' (pick the variable associated with the first contrast), or a value specifying a specific column in the observations."
                 }
             },
             "fa_icon": "fas fa-chart-area",
-            "required": ["exploratory_clustering_method", "exploratory_cor_method", "exploratory_n_features"]
+            "required": [
+                "exploratory_clustering_method",
+                "exploratory_cor_method",
+                "exploratory_n_features",
+                "exploratory_main_variable"
+            ]
         },
         "differential_analysis": {
             "title": "Differential analysis",


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

This PR 

 - partially resolves https://github.com/nf-core/differentialabundance/issues/31, based on https://github.com/pinin4fjords/shinyngs/pull/29 and https://github.com/pinin4fjords/shinyngs/pull/30. Box plots are optimised to not show facets side-by-side (even though it's useful) unless sample numbers are small, and to not make font sizes unnecessarily big.  (Ultimately we'll need to do better than boxplotting when we have larger sample numbers)
 - Adds pass-through of differential variables to the standalone differential plotting step. 
 - Adds outlier plots to the main report (I'd forgotten to do that)
 - Adds an option to control the 'main' variable used to group samples in exploratory analysis.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
