### PR TITLE
use color scales appropriate to variable, apply upstream palette fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
- - [[#93](https://github.com/nf-core/differentialabundance/issues/93) - Shouldn't be re-using the single exploratory palette across multiple informative variables  ([@pinin4fjords](https://github.com/pinin4fjords), review by )
+- [[#93](https://github.com/nf-core/differentialabundance/issues/93) - Shouldn't be re-using the single exploratory palette across multiple informative variables ([@pinin4fjords](https://github.com/pinin4fjords), review by )
 
 ## v1.1.1 - 2023-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+ - [[#93](https://github.com/nf-core/differentialabundance/issues/93) - Shouldn't be re-using the single exploratory palette across multiple informative variables  ([@pinin4fjords](https://github.com/pinin4fjords), review by )
+
 ## v1.1.1 - 2023-03-02
 
 ### `Fixed`

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -636,7 +636,7 @@ for (assay_type in rev(names(assay_data))){
         params$features_type, 
         "s\n(", params$exploratory_clustering_method, " clustering, ", params$exploratory_cor_method, " correlation)"),
       cluster_method = params$exploratory_clustering_method,
-      palette = groupColorScale,
+      palette = dendroColorScale,
       labelspace = 0.25
     )
     # Defaults in shinyngs make the text in this plot a bit big for the report, so

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -530,6 +530,7 @@ for (assay_type in rev(names(assay_data))){
       observations[[iv]], 
       levels = unique(observations[[iv]])
     )
+    pcaColorScale <- makeColorScale(length(unique(observations[[iv]])), palette = params$exploratory_palette_name)
 
     # Make plotting data combining PCA coords with coloring groups etc
 
@@ -551,7 +552,7 @@ for (assay_type in rev(names(assay_data))){
         ylab = labels[2],
         colorby = plotdata$colorby,
         plot_type = plot_types[[d]],
-        palette = groupColorScale,
+        palette = pcaColorScale,
         legend_title = prettifyVariablename(iv),
         labels = plotdata$name,
         show_labels = TRUE
@@ -621,6 +622,8 @@ for (assay_type in rev(names(assay_data))){
     cat(paste0("\n##### ", prettifyVariablename(assay_type), " (", iv, ")\n"))
     variable_genes <- selectVariableGenes(matrix = assay_data[[assay_type]], ntop = params$exploratory_n_features)
 
+    dendroColorScale <- makeColorScale(length(unique(observations[[iv]])), palette = params$exploratory_palette_name)
+    
     p <- clusteringDendrogram(
       2^assay_data[[assay_type]][variable_genes, ],
       observations[, iv, drop = FALSE],

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -269,8 +269,8 @@ process {
     }
 
     withName: RMARKDOWNNOTEBOOK {
-        conda = "bioconda::r-shinyngs=1.5.5"
-        container = { "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.5--r42hdfd78af_0':'quay.io/biocontainers/r-shinyngs:1.5.5--r42hdfd78af_0' }" }
+        conda = "bioconda::r-shinyngs=1.5.8"
+        container = { "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.8--r42hdfd78af_0':'quay.io/biocontainers/r-shinyngs:1.5.8--r42hdfd78af_0' }" }
         publishDir = [
             path: { "${params.outdir}/report" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -269,8 +269,8 @@ process {
     }
 
     withName: RMARKDOWNNOTEBOOK {
-        conda = "bioconda::r-shinyngs=1.5.8"
-        container = { "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.8--r42hdfd78af_0':'quay.io/biocontainers/r-shinyngs:1.5.8--r42hdfd78af_0' }" }
+        conda = "bioconda::r-shinyngs=1.5.9"
+        container = { "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.9--r42hdfd78af_0':'quay.io/biocontainers/r-shinyngs:1.5.9--r42hdfd78af_0' }" }
         publishDir = [
             path: { "${params.outdir}/report" },
             mode: params.publish_dir_mode,

--- a/modules.json
+++ b/modules.json
@@ -62,17 +62,17 @@
                     },
                     "shinyngs/staticdifferential": {
                         "branch": "master",
-                        "git_sha": "c2f6d050ce2f4db1436a3616cd0dad0929e6ffcd",
+                        "git_sha": "1b97cf15709524fbc0679ca14a7ad3262eba979b",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/staticexploratory": {
                         "branch": "master",
-                        "git_sha": "c2f6d050ce2f4db1436a3616cd0dad0929e6ffcd",
+                        "git_sha": "1b97cf15709524fbc0679ca14a7ad3262eba979b",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/validatefomcomponents": {
                         "branch": "master",
-                        "git_sha": "c2f6d050ce2f4db1436a3616cd0dad0929e6ffcd",
+                        "git_sha": "1b97cf15709524fbc0679ca14a7ad3262eba979b",
                         "installed_by": ["modules"]
                     },
                     "untar": {

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICDIFFERENTIAL {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.5.6"
+    conda "bioconda::r-shinyngs=1.5.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.6--r42hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.6--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.9--r42hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.9--r42hdfd78af_0' }"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICEXPLORATORY {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.5.6"
+    conda "bioconda::r-shinyngs=1.5.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.6--r42hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.6--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.9--r42hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.9--r42hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
     tag "$sample"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.5.6"
+    conda "bioconda::r-shinyngs=1.5.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.6--r42hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.6--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.9--r42hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.9--r42hdfd78af_0' }"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

closes https://github.com/nf-core/differentialabundance/issues/93

This PR addresses an issue caused by not customising the palette when different discrete variables are used for coloring. It also incorporates related fixes from upstream (https://github.com/pinin4fjords/shinyngs/pull/37, https://github.com/pinin4fjords/shinyngs/pull/38). 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
