### PR TITLE
Don't use contrasts directly from the input channel

### DIFF
--- a/workflows/differentialabundance.nf
+++ b/workflows/differentialabundance.nf
@@ -515,7 +515,7 @@ workflow DIFFERENTIALABUNDANCE {
     ch_report_input_files = ch_all_matrices
         .map{ it.tail() }
         .map{it.flatten()}
-        .combine(ch_contrasts_file.map{it.tail()})
+        .combine(VALIDATOR.out.contrasts.map{it.tail()})
         .combine(CUSTOM_DUMPSOFTWAREVERSIONS.out.yml)
         .combine(ch_logo_file)
         .combine(ch_css_file)


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

Tiny fix to use contrasts from the validator process rather than directly from the input file. That allows us to buffer any assumptions on contrasts file structure via that process.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
