### PR TITLE
Add optional scree plot to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [[#192](https://github.com/nf-core/differentialabundance/pull/192)] - Fix GSEA indent in report ([@WackerO](https://github.com/WackerO), review by [@pinin4fjords](https://github.com/pinin4fjords))
+
 ### `Changed`
 
 ## v1.3.1 - 2023-10-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-### `Fixed`
+- [[#192](https://github.com/nf-core/differentialabundance/pull/192)] - Add scree plot in report ([@WackerO](https://github.com/WackerO), review by [@pinin4fjords](https://github.com/pinin4fjords))
 
-- [[#192](https://github.com/nf-core/differentialabundance/pull/192)] - Fix GSEA indent in report ([@WackerO](https://github.com/WackerO), review by [@pinin4fjords](https://github.com/pinin4fjords))
+### `Fixed`
 
 ### `Changed`
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -501,7 +501,6 @@ percentVar_list <- list()
 for (assay_type in rev(names(assay_data))){
   
   pca_data <- pca_datas[[assay_type]]
-  percentVar_list[[assay_type]] <- list()
   for (iv in informative_variables){
   
     cat(paste0("\n##### ", prettifyVariablename(assay_type), " (", iv, ")\n"))
@@ -546,7 +545,9 @@ for (assay_type in rev(names(assay_data))){
 
       print(htmltools::tagList(do.call("plotly_scatterplot", plot_args)))
     }
-    percentVar_list[[assay_type]][[iv]] <- percentVar
+    if (! assay_type %in% names(percentVar_list)){
+      percentVar_list[[assay_type]] <- percentVar
+    }
   }
 }
 ```
@@ -554,24 +555,22 @@ for (assay_type in rev(names(assay_data))){
 ```{r, echo=FALSE, results='asis', eval=params$report_scree}
 cat(paste0("\n#### Scree plot {.tabset}"))
 cat(paste0("\nThe following scree plot visualizes what percentage of total variation in the data can be explained by each of the principal components computed.\n"))
+#iv <- informative_variables[1]
 
 for (assay_type in names(percentVar_list)) {
-  for (iv in names(percentVar_list[[assay_type]])) {
-    percentVarData <- data.frame(percentVar_list[[assay_type]][[iv]])
-    colnames(percentVarData) <- c("var_explained")
-    percentVarData$PCA <- as.numeric(rownames(percentVarData))
-    write.table(percentVarData, file=paste0("/home-link/iivow01/git/save_differentialabundance/error/", assay_type, "_", iv, "_varex.tsv"), quote=F, sep="\t")
-    cat(paste0("\n##### ", prettifyVariablename(assay_type), " (", iv, ")\n"))
-    print(
-      ggplot(percentVarData, aes(x=factor(PCA),y=var_explained, group=1)) +
-      theme_bw() +
-      geom_point(size=4) +
-      geom_line(linetype="dashed") +
-      xlab("PC") +
-      ylab("Percent variance explained")
-    )
-    cat("\n")
-  }
+  percentVarData <- data.frame(percentVar_list[[assay_type]])
+  colnames(percentVarData) <- c("var_explained")
+  percentVarData$PCA <- as.numeric(rownames(percentVarData))
+  cat(paste0("\n##### ", prettifyVariablename(assay_type), "\n"))
+  print(
+    ggplot(percentVarData, aes(x=factor(PCA),y=var_explained, group=1)) +
+    theme_bw() +
+    geom_point(size=4) +
+    geom_line(linetype="dashed") +
+    xlab("PC") +
+    ylab("Percent variance explained")
+  )
+  cat("\n")
 }
 ```
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -24,6 +24,7 @@ params:
   report_title: NULL,
   report_author: NULL,
   report_description: NULL,
+  report_scree: NULL
   observations_type: NULL
   observations: NULL                                          # GSE156533.samplesheet.csv
   observations_id_col: NULL
@@ -495,10 +496,12 @@ cat(paste0("\n### ", ucfirst(params$observations_type), " relationships\n"))
 Principal components analysis was conducted based on the `r params$exploratory_n_features` most variable `r params$features_type`s. Each component was annotated with its percent contribution to variance. 
 
 ```{r, echo=FALSE, results='asis'}
+# Create nested list to save the percentVars for reusing in the scree plot
+percentVar_list <- list()
 for (assay_type in rev(names(assay_data))){
   
   pca_data <- pca_datas[[assay_type]]
-
+  percentVar_list[[assay_type]] <- list()
   for (iv in informative_variables){
   
     cat(paste0("\n##### ", prettifyVariablename(assay_type), " (", iv, ")\n"))
@@ -543,6 +546,31 @@ for (assay_type in rev(names(assay_data))){
 
       print(htmltools::tagList(do.call("plotly_scatterplot", plot_args)))
     }
+    percentVar_list[[assay_type]][[iv]] <- percentVar
+  }
+}
+```
+
+```{r, echo=FALSE, results='asis', eval=params$report_scree}
+cat(paste0("\n#### Scree plot {.tabset}"))
+cat(paste0("\nThe following scree plot visualizes what percentage of total variation in the data can be explained by each of the principal components computed.\n"))
+
+for (assay_type in names(percentVar_list)) {
+  for (iv in names(percentVar_list[[assay_type]])) {
+    percentVarData <- data.frame(percentVar_list[[assay_type]][[iv]])
+    colnames(percentVarData) <- c("var_explained")
+    percentVarData$PCA <- as.numeric(rownames(percentVarData))
+    write.table(percentVarData, file=paste0("/home-link/iivow01/git/save_differentialabundance/error/", assay_type, "_", iv, "_varex.tsv"), quote=F, sep="\t")
+    cat(paste0("\n##### ", prettifyVariablename(assay_type), " (", iv, ")\n"))
+    print(
+      ggplot(percentVarData, aes(x=factor(PCA),y=var_explained, group=1)) +
+      theme_bw() +
+      geom_point(size=4) +
+      geom_line(linetype="dashed") +
+      xlab("PC") +
+      ylab("Percent variance explained")
+    )
+    cat("\n")
   }
 }
 ```

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ params {
     report_title               = null
     report_author              = null
     report_description         = null
-    report_scree               = false
+    report_scree               = true
 
     // Sample sheet options
     observations_type          = 'sample'

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ params {
     report_title               = null
     report_author              = null
     report_description         = null
+    report_scree               = false
 
     // Sample sheet options
     observations_type          = 'sample'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -952,6 +952,11 @@
                     "default": "None",
                     "fa_icon": "fas fa-feather",
                     "description": "A description for reporting outputs"
+                },
+                "report_scree": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Whether to generate a scree plot in the report"
                 }
             },
             "required": ["report_file", "logo_file", "css_file"]

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -955,7 +955,7 @@
                 },
                 "report_scree": {
                     "type": "boolean",
-                    "default": "false",
+                    "default": "true",
                     "description": "Whether to generate a scree plot in the report"
                 }
             },


### PR DESCRIPTION
This PR adds a scree plot to the report; it is optional, `--report_scree` is for now false by default:
[SRP254919_scree.html.zip](https://github.com/nf-core/differentialabundance/files/13297433/SRP254919_scree.html.zip)
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
