### PR TITLE
Add DESeq text to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [[#193](https://github.com/nf-core/differentialabundance/pull/193)] - Add DESeq2 text to report ([@WackerO](https://github.com/WackerO), review by [@pinin4fjords](https://github.com/pinin4fjords))
+
 ### `Fixed`
 
 ### `Changed`

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -882,22 +882,6 @@ make_params_table('exploratory analysis', 'exploratory_', remove_pattern = TRUE)
 
 ## Differential analysis
 
-```{r, echo=FALSE, results='asis', eval=params$study_type %in% c('rnaseq')}
-# For DESeq2, add some more explanation to the report
-cat(paste0(
-"The `DESeq2 R` package was used for differential analysis. p-values were adjusted with the ",
-params$deseq2_p_adjust_method,
-" method to reduce the number of false positives (",
-params$features_type,
-"s that are not actually differential). ",
-ucfirst(params$features_type),
-"s were considered differential if, for the respective contrast, the adjusted p-value was equal to or lower than ",
-params$deseq2_alpha,
-" and the absolute log2 fold change was equal to or higher than ",
-params$deseq2_lfc_threshold,
-"."
-))
-```
 
 ```{r, echo=FALSE, results='asis'}
 if (params$study_type == 'rnaseq'){

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -681,15 +681,6 @@ cat(paste0(
 "The `DESeq2 R` package was used for differential analysis. p-values were adjusted with the ", params$deseq2_p_adjust_method, " method to reduce the number of false positives. ", ucfirst(params$features_type), "s were considered differential if, for the respective contrast, the adjusted p-value was equal to or lower than ", params$deseq2_alpha, " and the absolute log2 fold change was equal to or higher than ", params$deseq2_lfc_threshold, "."
 ))
 ```
-```{r, echo=FALSE, results='asis'}
-cat(paste0(
-"The following tables and volcano plots show how many and which ",
-params$features_type,
-"s were found to be differential in each contrast. In the plots, a ",
-params$features_type,
-" is colored differently depending on whether it was determined not differential, or differential according to log2 foldchange, or differential according to adjusted p-value, or differential according to both."
-))
-```
 
 ### Differential `r params$features_type` `r params$study_abundance_type` {.tabset}
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -678,17 +678,7 @@ foo <- lapply(informative_variables[iv_min_group_sizes > 2], function(iv){
 ```{r, echo=FALSE, results='asis', eval=params$study_type %in% c('rnaseq')}
 # For DESeq2, add some more explanation to the report
 cat(paste0(
-"The `DESeq2 R` package was used for differential analysis. p-values were adjusted with the ",
-params$deseq2_p_adjust_method,
-" method to reduce the number of false positives (",
-params$features_type,
-"s that are not actually differential). ",
-ucfirst(params$features_type),
-"s were considered differential if, for the respective contrast, the adjusted p-value was equal to or lower than ",
-params$deseq2_alpha,
-" and the absolute log2 fold change was equal to or higher than ",
-params$deseq2_lfc_threshold,
-"."
+"The `DESeq2 R` package was used for differential analysis. p-values were adjusted with the ", params$deseq2_p_adjust_method, " method to reduce the number of false positives. ", ucfirst(params$features_type), "s were considered differential if, for the respective contrast, the adjusted p-value was equal to or lower than ", params$deseq2_alpha, " and the absolute log2 fold change was equal to or higher than ", params$deseq2_lfc_threshold, "."
 ))
 ```
 ```{r, echo=FALSE, results='asis'}

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -671,10 +671,35 @@ foo <- lapply(informative_variables[iv_min_group_sizes > 2], function(iv){
     }
   }
 })
-
 ```
 
 ## Differential analysis
+
+```{r, echo=FALSE, results='asis', eval=params$study_type %in% c('rnaseq')}
+# For DESeq2, add some more explanation to the report
+cat(paste0(
+"The `DESeq2 R` package was used for differential analysis. p-values were adjusted with the ",
+params$deseq2_p_adjust_method,
+" method to reduce the number of false positives (",
+params$features_type,
+"s that are not actually differential). ",
+ucfirst(params$features_type),
+"s were considered differential if, for the respective contrast, the adjusted p-value was equal to or lower than ",
+params$deseq2_alpha,
+" and the absolute log2 fold change was equal to or higher than ",
+params$deseq2_lfc_threshold,
+"."
+))
+```
+```{r, echo=FALSE, results='asis'}
+cat(paste0(
+"The following tables and volcano plots show how many and which ",
+params$features_type,
+"s were found to be differential in each contrast. In the plots, a ",
+params$features_type,
+" is colored differently depending on whether it was determined not differential, or differential according to log2 foldchange, or differential according to adjusted p-value, or differential according to both."
+))
+```
 
 ### Differential `r params$features_type` `r params$study_abundance_type` {.tabset}
 
@@ -856,6 +881,23 @@ make_params_table('exploratory analysis', 'exploratory_', remove_pattern = TRUE)
 ```
 
 ## Differential analysis
+
+```{r, echo=FALSE, results='asis', eval=params$study_type %in% c('rnaseq')}
+# For DESeq2, add some more explanation to the report
+cat(paste0(
+"The `DESeq2 R` package was used for differential analysis. p-values were adjusted with the ",
+params$deseq2_p_adjust_method,
+" method to reduce the number of false positives (",
+params$features_type,
+"s that are not actually differential). ",
+ucfirst(params$features_type),
+"s were considered differential if, for the respective contrast, the adjusted p-value was equal to or lower than ",
+params$deseq2_alpha,
+" and the absolute log2 fold change was equal to or higher than ",
+params$deseq2_lfc_threshold,
+"."
+))
+```
 
 ```{r, echo=FALSE, results='asis'}
 if (params$study_type == 'rnaseq'){


### PR DESCRIPTION
This PR adds a bit of explanatory text to the report about the DE analysis; for now only if DESeq2 is run:
[SRP254919_text.html.zip](https://github.com/nf-core/differentialabundance/files/13297446/SRP254919_text.html.zip)
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
