### PR TITLE
Added colors to volcano

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [[#194](https://github.com/nf-core/differentialabundance/pull/194)] - Change report volcano colors ([@WackerO](https://github.com/WackerO), review by [@pinin4fjords](https://github.com/pinin4fjords))
+
 ## v1.3.1 - 2023-10-26
 
 ### `Added`

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -733,8 +733,10 @@ for (i in 1:nrow(contrasts)){
     cat("\n##### ", pvt, " p values\n")
     pval_column <- p_value_types[[pvt]]
   
-    full_de$differential_status <- FALSE
-    full_de$differential_status[abs(full_de[[params$differential_fc_column]]) > log2(params$differential_min_fold_change) & full_de[[pval_column]] < p_value_thresholds[[pvt]]] <- TRUE
+    full_de$differential_status <- "Not significant"
+    full_de$differential_status[abs(full_de[[params$differential_fc_column]]) > log2(params$differential_min_fold_change)] <- paste("abs(logFC) >", params$differential_min_fold_change)
+    full_de$differential_status[full_de[[pval_column]] < p_value_thresholds[[pvt]]] <- paste(pvt, "<=", p_value_thresholds[[pvt]])
+    full_de$differential_status[abs(full_de[[params$differential_fc_column]]) > log2(params$differential_min_fold_change) & full_de[[pval_column]] < p_value_thresholds[[pvt]]] <- paste("abs(logFC) >", params$differential_min_fold_change, "&", pvt, "<=", p_value_thresholds[[pvt]])
 
     # Define the thresholds we'll draw
 
@@ -742,7 +744,10 @@ for (i in 1:nrow(contrasts)){
     hline_thresholds[[paste(pval_column, '=', p_value_thresholds[[pvt]])]] = -log10(p_value_thresholds[[pvt]])
     vline_thresholds[[paste(params$differential_fc_column, '<-', log2(params$differential_min_fold_change))]] = -log2(params$differential_min_fold_change)
     vline_thresholds[[paste(params$differential_fc_column, '>', log2(params$differential_min_fold_change))]] = log2(params$differential_min_fold_change)
-
+    
+    palette_volcano <- makeColorScale(4, params$differential_palette_name)
+    names(palette_volcano) <- c("Not significant", paste("abs(logFC) >", params$differential_min_fold_change), paste(pvt, "<=", p_value_thresholds[[pvt]]), paste("abs(logFC) >", params$differential_min_fold_change, "&", pvt, "<=", p_value_thresholds[[pvt]]))
+    
     plot_args <- list(
       x = full_de[[params$differential_fc_column]],
       y = -log10(full_de[[pval_column]]),
@@ -754,7 +759,7 @@ for (i in 1:nrow(contrasts)){
       vline_thresholds = vline_thresholds,
       show_labels = FALSE,
       legend_title = "Differential status",
-      palette = makeColorScale(2, params$differential_palette_name)
+      palette = palette_volcano
     )
   
     # Let's equalize the axes

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -772,11 +772,13 @@ for (i in 1:nrow(contrasts)){
     de_pval <- full_de[[pval_column]] <= p_value_thresholds[[pvt]]
     de_pval_label <- paste(pvt, "<=", p_value_thresholds[[pvt]])
     
+    de_pval_fc_label <- paste(de_fc_label, '&', de_pval_label)
+    
     full_de$differential_status <- "Not significant"
     full_de$differential_status[de_fc] <- de_fc_label
     full_de$differential_status[de_pval] <- de_pval_label
-    full_de$differential_status[de_fc & de_pval] <- paste(de_fc_label, '&', de_pval_label)
-    full_de$differential_status <- factor(full_de$differential_status, levels = c("Not significant", de_fc_label, de_pval_label, paste(de_fc_label, '&', de_pval_label)), ordered = TRUE) # Factorize status so that non-significant is always first
+    full_de$differential_status[de_fc & de_pval] <- de_pval_fc_label
+    full_de$differential_status <- factor(full_de$differential_status, levels = c("Not significant", de_fc_label, de_pval_label, de_pval_fc_label), ordered = TRUE) # Factorize status so that non-significant is always first
     # Define the thresholds we'll draw
 
     hline_thresholds = vline_thresholds = list()

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -753,7 +753,6 @@ for (i in 1:nrow(contrasts)){
     vline_thresholds[[paste(params$differential_fc_column, '>', log2(params$differential_min_fold_change))]] = log2(params$differential_min_fold_change)
     
     palette_volcano <- makeColorScale(4, params$differential_palette_name)
-    names(palette_volcano) <- c("Not significant", paste("abs(logFC) >", params$differential_min_fold_change), paste(pvt, "<=", p_value_thresholds[[pvt]]), paste("abs(logFC) >", params$differential_min_fold_change, "&", pvt, "<=", p_value_thresholds[[pvt]]))
     
     plot_args <- list(
       x = full_de[[params$differential_fc_column]],

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -733,10 +733,17 @@ for (i in 1:nrow(contrasts)){
     cat("\n##### ", pvt, " p values\n")
     pval_column <- p_value_types[[pvt]]
   
+    
+    de_fc <- abs(full_de[[params$differential_fc_column]]) > log2(params$differential_min_fold_change)
+    de_fc_label <- paste("abs(logFC) >", params$differential_min_fold_change)
+    
+    de_pval <- full_de[[pval_column]] < p_value_thresholds[[pvt]]]
+    de_pval_label <- paste(pvt, "<=", p_value_thresholds[[pvt]])
+    
     full_de$differential_status <- "Not significant"
-    full_de$differential_status[abs(full_de[[params$differential_fc_column]]) > log2(params$differential_min_fold_change)] <- paste("abs(logFC) >", params$differential_min_fold_change)
-    full_de$differential_status[full_de[[pval_column]] < p_value_thresholds[[pvt]]] <- paste(pvt, "<=", p_value_thresholds[[pvt]])
-    full_de$differential_status[abs(full_de[[params$differential_fc_column]]) > log2(params$differential_min_fold_change) & full_de[[pval_column]] < p_value_thresholds[[pvt]]] <- paste("abs(logFC) >", params$differential_min_fold_change, "&", pvt, "<=", p_value_thresholds[[pvt]])
+    full_de$differential_status[de_fc] <- de_fc_label
+    full_de$differential_status[de_pval] <- de_pval_label
+    full_de$differential_status[de_fc & de_pval] <- paste(de_fc_label, '&', de_pval_label)
 
     # Define the thresholds we'll draw
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -734,32 +734,32 @@ for (i in 1:nrow(contrasts)){
     pval_column <- p_value_types[[pvt]]
   
     
-    de_fc <- abs(full_de[[params$differential_fc_column]]) > log2(params$differential_min_fold_change)
-    de_fc_label <- paste("abs(logFC) >", params$differential_min_fold_change)
+    de_fc <- abs(full_de[[params$differential_fc_column]]) >= log2(params$differential_min_fold_change)
+    de_fc_label <- paste("abs(logFC) >=", params$differential_min_fold_change)
     
-    de_pval <- full_de[[pval_column]] < p_value_thresholds[[pvt]]]
+    de_pval <- full_de[[pval_column]] <= p_value_thresholds[[pvt]]
     de_pval_label <- paste(pvt, "<=", p_value_thresholds[[pvt]])
     
     full_de$differential_status <- "Not significant"
     full_de$differential_status[de_fc] <- de_fc_label
     full_de$differential_status[de_pval] <- de_pval_label
     full_de$differential_status[de_fc & de_pval] <- paste(de_fc_label, '&', de_pval_label)
-
+    full_de$differential_status <- factor(full_de$differential_status, levels = c("Not significant", de_fc_label, de_pval_label, paste(de_fc_label, '&', de_pval_label)), ordered = TRUE) # Factorize status so that non-significant is always first
     # Define the thresholds we'll draw
 
     hline_thresholds = vline_thresholds = list()
     hline_thresholds[[paste(pval_column, '=', p_value_thresholds[[pvt]])]] = -log10(p_value_thresholds[[pvt]])
-    vline_thresholds[[paste(params$differential_fc_column, '<-', log2(params$differential_min_fold_change))]] = -log2(params$differential_min_fold_change)
-    vline_thresholds[[paste(params$differential_fc_column, '>', log2(params$differential_min_fold_change))]] = log2(params$differential_min_fold_change)
+    vline_thresholds[[paste(params$differential_fc_column, '<=', log2(params$differential_min_fold_change))]] = -log2(params$differential_min_fold_change)
+    vline_thresholds[[paste(params$differential_fc_column, '>=', log2(params$differential_min_fold_change))]] = log2(params$differential_min_fold_change)
     
-    palette_volcano <- makeColorScale(4, params$differential_palette_name)
-    
+    palette_volcano <- append(c('#999999'), makeColorScale(3, params$differential_palette_name)) # set non-significant to gray
+
     plot_args <- list(
       x = full_de[[params$differential_fc_column]],
       y = -log10(full_de[[pval_column]]),
       colorby = full_de$differential_status,
       ylab = paste("-log(10)", pval_column),
-      xlab = xlabel <- paste("higher in", contrasts$reference[i], "          <<", params$differential_fc_column, ">>           higher in", contrasts$target[i]) ,
+      xlab = xlabel <- paste("higher in", contrasts$reference[i], "          <<", params$differential_fc_column, ">>           higher in", contrasts$target[i]),
       labels = full_de[[label_col]],
       hline_thresholds = hline_thresholds,
       vline_thresholds = vline_thresholds,


### PR DESCRIPTION
This PR marks the points in the report volcano plots by color depending on their DE status (not DE, logFC DE, pval DE, logFC&pval DE). Motivated by a colleague who found https://bioconductor.org/packages/devel/bioc/vignettes/EnhancedVolcano/inst/doc/EnhancedVolcano.html (but I did not use that package):
[SRP254919_volcano.html.zip](https://github.com/nf-core/differentialabundance/files/13297458/SRP254919_volcano.html.zip)
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
