### PR TITLE
GSEA- pngs and htmls in same place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [[#265](https://github.com/nf-core/differentialabundance/pull/265) - GSEA- pngs and htmls in same place ([@pinin4fjords](https://github.com/pinin4fjords), review by [@WackerO](https://github.com/WackerO))
 - [[#257](https://github.com/nf-core/differentialabundance/pull/257)] - Fixed FILTER_DIFFTABLE module, updated PROTEUS module to better handle whitespace in prefix param, made docs clearer ([@WackerO](https://github.com/WackerO), review by [@pinin4fjords](https://github.com/pinin4fjords))
 - [[#254](https://github.com/nf-core/differentialabundance/pull/254)] - Made differential_file_suffix optional ([@WackerO](https://github.com/WackerO), review by [@pinin4fjords](https://github.com/pinin4fjords))
 - [[#240](https://github.com/nf-core/differentialabundance/pull/240)] - Publish GSEA reports ([@pinin4fjords](https://github.com/pinin4fjords), review by [@WackerO](https://github.com/WackerO))

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -295,14 +295,9 @@ process {
         ext.prefix = { "${meta.id}.${gene_sets.baseName}." }
         publishDir = [
             [
-                path: { "${params.outdir}/tables/gsea/${meta.id}/${gene_sets.baseName}" },
+                path: { "${params.outdir}/report/gsea/${meta.id}/${gene_sets.baseName}" },
                 mode: params.publish_dir_mode,
-                pattern: '*gsea_report_for_*.tsv'
-            ],
-            [
-                path: { "${params.outdir}/html/gsea/${meta.id}/${gene_sets.baseName}" },
-                mode: params.publish_dir_mode,
-                pattern: '*.{html,zip,png}'
+                pattern: '*.{html,zip,png,*gsea_report_for_*.tsv}'
             ]
         ]
         ext.args = { [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -300,14 +300,9 @@ process {
                 pattern: '*gsea_report_for_*.tsv'
             ],
             [
-                path: { "${params.outdir}/plots/gsea/${meta.id}/${gene_sets.baseName}" },
-                mode: params.publish_dir_mode,
-                pattern: '*.png'
-            ],
-            [
                 path: { "${params.outdir}/html/gsea/${meta.id}/${gene_sets.baseName}" },
                 mode: params.publish_dir_mode,
-                pattern: '*.{html,zip}'
+                pattern: '*.{html,zip,png}'
             ]
         ]
         ext.args = { [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -297,7 +297,7 @@ process {
             [
                 path: { "${params.outdir}/report/gsea/${meta.id}/${gene_sets.baseName}" },
                 mode: params.publish_dir_mode,
-                pattern: '*.{html,zip,png,tsv}'
+                pattern: '*.{html,zip,png,tsv,rpt}'
             ]
         ]
         ext.args = { [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -297,7 +297,7 @@ process {
             [
                 path: { "${params.outdir}/report/gsea/${meta.id}/${gene_sets.baseName}" },
                 mode: params.publish_dir_mode,
-                pattern: '*.{html,zip,png,*gsea_report_for_*.tsv}'
+                pattern: '*.{html,zip,png,tsv}'
             ]
         ]
         ext.args = { [


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

Placing HTMLs and PNGs for HTML in different directories is tidy, but breaks links to images used by the HTML. Publish to the same directory instead.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
