### PR TITLE
Bump shinyngs, fix contrasts passed to app creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [[#280](https://github.com/nf-core/differentialabundance/pull/280)] - Bump shinyngs, fix contrasts passed to app creation ([@pinin4fjords](https://github.com/pinin4fjords), review by [@WackerO](https://github.com/WackerO))
 - [[#274](https://github.com/nf-core/differentialabundance/pull/274)] - Fix pagination on samples table ([@pinin4fjords](https://github.com/pinin4fjords), review by [@WackerO](https://github.com/WackerO))
 - [[#272](https://github.com/nf-core/differentialabundance/pull/272)] - Show >10 contrasts in report ([@pinin4fjords](https://github.com/pinin4fjords), review by [@WackerO](https://github.com/WackerO))
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -420,7 +420,7 @@ process {
             ((params.report_title == null) ? '' : "--title \"$params.report_title\""),
             ((params.report_author == null) ? '' : "--author \"$params.report_author\""),
             ((params.report_description == null) ? '' : "--description \"$params.report_description\""),
-            ((params.shinyngs_guess_unlog_matrices) ? "--guess_unlog_matrices" : ''),
+            ( (params.study_type == 'maxquant') ? "--log2_assays ''" : (((params.exploratory_log2_assays == null) ? '' : "--log2_assays \"$params.exploratory_log2_assays\"".replace('[', '').replace(']', ''))) ),
             ((params.shinyngs_deploy_to_shinyapps_io) ? "--deploy_app" : ''),
             ((params.shinyngs_shinyapps_account == null) ? '' : "--shinyapps_account \"$params.shinyngs_shinyapps_account\""),
             ((params.shinyngs_shinyapps_app_name == null) ? '' : "--shinyapps_name \"$params.shinyngs_shinyapps_app_name\"")

--- a/modules.json
+++ b/modules.json
@@ -71,23 +71,23 @@
                         "installed_by": ["modules"]
                     },
                     "shinyngs/app": {
-                        "branch": "master",
-                        "git_sha": "85519fe9deccf2c5f7ff1f3b5d3494c61a794643",
+                        "branch": "bump_shinyngs",
+                        "git_sha": "fc5e93b84073ed8367fa6215f9ca52aac3d7dd9a",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/staticdifferential": {
-                        "branch": "master",
-                        "git_sha": "85519fe9deccf2c5f7ff1f3b5d3494c61a794643",
+                        "branch": "bump_shinyngs",
+                        "git_sha": "1cf0fc9ef6d1e4f3fd8ff3812e369da1c7970133",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/staticexploratory": {
-                        "branch": "master",
-                        "git_sha": "85519fe9deccf2c5f7ff1f3b5d3494c61a794643",
+                        "branch": "bump_shinyngs",
+                        "git_sha": "fc5e93b84073ed8367fa6215f9ca52aac3d7dd9a",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/validatefomcomponents": {
-                        "branch": "master",
-                        "git_sha": "85519fe9deccf2c5f7ff1f3b5d3494c61a794643",
+                        "branch": "bump_shinyngs",
+                        "git_sha": "1cf0fc9ef6d1e4f3fd8ff3812e369da1c7970133",
                         "installed_by": ["modules"]
                     },
                     "untar": {

--- a/modules.json
+++ b/modules.json
@@ -71,23 +71,23 @@
                         "installed_by": ["modules"]
                     },
                     "shinyngs/app": {
-                        "branch": "bump_shinyngs",
-                        "git_sha": "fc5e93b84073ed8367fa6215f9ca52aac3d7dd9a",
+                        "branch": "master",
+                        "git_sha": "91fc36585a50f9bae98cb5b3dff36ce64c83a6b4",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/staticdifferential": {
-                        "branch": "bump_shinyngs",
-                        "git_sha": "1cf0fc9ef6d1e4f3fd8ff3812e369da1c7970133",
+                        "branch": "master",
+                        "git_sha": "91fc36585a50f9bae98cb5b3dff36ce64c83a6b4",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/staticexploratory": {
-                        "branch": "bump_shinyngs",
-                        "git_sha": "fc5e93b84073ed8367fa6215f9ca52aac3d7dd9a",
+                        "branch": "master",
+                        "git_sha": "91fc36585a50f9bae98cb5b3dff36ce64c83a6b4",
                         "installed_by": ["modules"]
                     },
                     "shinyngs/validatefomcomponents": {
-                        "branch": "bump_shinyngs",
-                        "git_sha": "1cf0fc9ef6d1e4f3fd8ff3812e369da1c7970133",
+                        "branch": "master",
+                        "git_sha": "91fc36585a50f9bae98cb5b3dff36ce64c83a6b4",
                         "installed_by": ["modules"]
                     },
                     "untar": {

--- a/modules/nf-core/shinyngs/app/environment.yml
+++ b/modules/nf-core/shinyngs/app/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::r-shinyngs=1.8.8
+  - bioconda::r-shinyngs=2.0.0

--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -15,8 +15,8 @@ process SHINYNGS_APP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.8--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.8--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:2.0.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:2.0.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)    // Experiment-level info

--- a/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
@@ -4,41 +4,41 @@
             "data.rds",
             "app.R:md5,d41d8cd98f00b204e9800998ecf8427e",
             [
-                "versions.yml:md5,9a3135ae8ff362a9671b280dcc5781da"
+                "versions.yml:md5,a6c3af4b2fd261b4049c92449ea6bb4d"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-03T08:47:11.758494"
+        "timestamp": "2024-06-25T09:43:49.880332"
     },
     "mouse - multi matrix": {
         "content": [
             "data.rds",
             "app.R:md5,bedcfc45b6cdcc2b8fe3627987e2b17a",
             [
-                "versions.yml:md5,9a3135ae8ff362a9671b280dcc5781da"
+                "versions.yml:md5,a6c3af4b2fd261b4049c92449ea6bb4d"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-03T08:46:37.144273"
+        "timestamp": "2024-06-25T09:43:15.455356"
     },
     "mouse - single matrix": {
         "content": [
             "data.rds",
             "app.R:md5,bedcfc45b6cdcc2b8fe3627987e2b17a",
             [
-                "versions.yml:md5,9a3135ae8ff362a9671b280dcc5781da"
+                "versions.yml:md5,a6c3af4b2fd261b4049c92449ea6bb4d"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-03T08:46:57.227288"
+        "timestamp": "2024-06-25T09:43:35.309081"
     }
 }

--- a/modules/nf-core/shinyngs/staticdifferential/environment.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::r-shinyngs=1.8.8
+  - bioconda::r-shinyngs=2.0.0

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_STATICDIFFERENTIAL {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.8--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.8--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:2.0.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:2.0.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticexploratory/environment.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::r-shinyngs=1.8.8
+  - bioconda::r-shinyngs=2.0.0

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_STATICEXPLORATORY {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.8--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.8--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:2.0.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:2.0.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)

--- a/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
@@ -8,14 +8,14 @@
             "pca3d.png",
             "sample_dendrogram.png",
             [
-                "versions.yml:md5,526fbe61b95ad3a722d7470ca1874ca3"
+                "versions.yml:md5,e04025d7790ddfa09ba5bd719cfba8c7"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-03T08:48:20.908769"
+        "timestamp": "2024-06-25T10:24:53.456056"
     },
     "mouse - defaults": {
         "content": [
@@ -26,14 +26,14 @@
             "pca3d.png",
             "sample_dendrogram.png",
             [
-                "versions.yml:md5,526fbe61b95ad3a722d7470ca1874ca3"
+                "versions.yml:md5,e04025d7790ddfa09ba5bd719cfba8c7"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-03T08:48:06.589763"
+        "timestamp": "2024-06-25T10:24:39.111271"
     },
     "mouse - specify log": {
         "content": [
@@ -44,14 +44,14 @@
             "pca3d.png",
             "sample_dendrogram.png",
             [
-                "versions.yml:md5,526fbe61b95ad3a722d7470ca1874ca3"
+                "versions.yml:md5,e04025d7790ddfa09ba5bd719cfba8c7"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-03T08:48:41.352789"
+        "timestamp": "2024-06-25T10:25:14.646472"
     },
     "mouse - html": {
         "content": [
@@ -67,13 +67,13 @@
             false,
             false,
             [
-                "versions.yml:md5,526fbe61b95ad3a722d7470ca1874ca3"
+                "versions.yml:md5,e04025d7790ddfa09ba5bd719cfba8c7"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-03T08:49:04.969108"
+        "timestamp": "2024-06-25T10:25:38.256352"
     }
 }

--- a/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::r-shinyngs=1.8.8
+  - bioconda::r-shinyngs=2.0.0

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.8--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.8--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:2.0.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:2.0.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)

--- a/nextflow.config
+++ b/nextflow.config
@@ -176,7 +176,6 @@ params {
 
     // ShinyNGS
     shinyngs_build_app              = true
-    shinyngs_guess_unlog_matrices   = true
 
     // Note: for shinyapps deployment, in addition to setting these values,
     // SHINYAPPS_TOKEN and SHINYAPPS_SECRET must be available to the

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -979,12 +979,6 @@
                     "default": "null",
                     "description": "The name of the app to push to in your shinyapps.io account",
                     "fa_icon": "fas fa-file-signature"
-                },
-                "shinyngs_guess_unlog_matrices": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Should we guess the log status of matrices and unlog for the app?",
-                    "help_text": "In the app context, it's usually helpful if things are not in log scale, so that e.g. fold changes make some sense with respect to observed values. This flag will cause the shinyngs app-building script to make a guess based on observed values as to the log status of input matrices, and adjust the loading accordingly."
                 }
             },
             "fa_icon": "fab fa-app-store-ios"

--- a/workflows/differentialabundance.nf
+++ b/workflows/differentialabundance.nf
@@ -584,9 +584,9 @@ workflow DIFFERENTIALABUNDANCE {
         // Make a new contrasts file from the differential metas to guarantee the
         // same order as the differential results
 
-        ch_app_differential = ch_differential.first().map{it[0].keySet().join(',')}
+        ch_app_differential = ch_differential.first().map{it[0].keySet().tail().join(',')}
             .concat(
-                ch_differential.map{it[0].values().join(',')}
+                ch_differential.map{it[0].values().tail().join(',')}
             )
             .collectFile(name: 'contrasts.csv', newLine: true, sort: false)
             .map{


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

This PR fixes two problems:

- Earlier work to tie in the `log2_assays` parameter impacted on the exploratory plotting script, but not the app building. This led to incorrect logging of matrices in the app. The PR passes the parameter to shinyngs, which had to be updated to pass the argument correctly internally. This replaces previous 'guessing' functionality related to log status, in line with previous work on the exploratory script.
- 'Higher in' messages underneath differential plots were broken in the app, because contrasts were being passed to app creation incorrectly. We just needed to remove the first `id` part of the contrast passes around internal to differentialabundance. 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
