### PR TITLE
add additional reference to wiki article for MAD

### DIFF
--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -726,7 +726,7 @@ iv_min_group_sizes <- unlist(lapply(informative_variables, function(x) min(table
 
 if (any(iv_min_group_sizes > 2)){
     cat("\n### Outlier detection {.tabset}\n")
-    cat("\nOutlier detection based on [median absolute deviation](https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf) was undertaken, the outlier scoring is plotted below. For more on MAD, see [this wiki article](https://en.wikipedia.org/wiki/Median_absolute_deviation).\n")
+    cat("\nOutlier detection based on [median absolute deviation](https://archive.ph/o3thZ) was undertaken, the outlier scoring is plotted below. For more on MAD, see [this wiki article](https://en.wikipedia.org/wiki/Median_absolute_deviation).\n")
 }
 
 foo <- lapply(informative_variables[iv_min_group_sizes > 2], function(iv){

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -726,7 +726,7 @@ iv_min_group_sizes <- unlist(lapply(informative_variables, function(x) min(table
 
 if (any(iv_min_group_sizes > 2)){
     cat("\n### Outlier detection {.tabset}\n")
-    cat("\nOutlier detection based on [median absolute deviation](https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf) was undertaken, the outlier scoring is plotted below.\n")
+    cat("\nOutlier detection based on [median absolute deviation](https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf) was undertaken, the outlier scoring is plotted below. For more on MAD, see [this wiki article](https://en.wikipedia.org/wiki/Median_absolute_deviation).\n")
 }
 
 foo <- lapply(informative_variables[iv_min_group_sizes > 2], function(iv){

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -373,7 +373,7 @@
                 "exploratory_mad_threshold": {
                     "type": "integer",
                     "default": -5,
-                    "help_text": "MAD = median absolute deviation. A threshold on this value is used to define observations (samples) as outliers, or not, in exploratory plots. Based on the definition at https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf. For more on MAD, see https://en.wikipedia.org/wiki/Median_absolute_deviation.",
+                    "help_text": "MAD = median absolute deviation. A threshold on this value is used to define observations (samples) as outliers, or not, in exploratory plots. Based on the definition at https://archive.ph/o3thZ. For more on MAD, see https://en.wikipedia.org/wiki/Median_absolute_deviation.",
                     "description": "Threshold on MAD score for outlier identification",
                     "fa_icon": "fas fa-angry"
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -373,7 +373,7 @@
                 "exploratory_mad_threshold": {
                     "type": "integer",
                     "default": -5,
-                    "help_text": "MAD = median absolute deviation. A threshold on this value is used to define observations (samples) as outliers, or not, in exploratory plots. Based on the definition at https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf. ",
+                    "help_text": "MAD = median absolute deviation. A threshold on this value is used to define observations (samples) as outliers, or not, in exploratory plots. Based on the definition at https://wiki.arrayserver.com/wiki/index.php?title=CorrelationQC.pdf. For more on MAD, see https://en.wikipedia.org/wiki/Median_absolute_deviation.",
                     "description": "Threshold on MAD score for outlier identification",
                     "fa_icon": "fas fa-angry"
                 },


### PR DESCRIPTION
This PR adds an additional reference to the wiki article on MAD. Note that I did not replace the existing link, but added a second one to point to an article that users can read to understand more about MAD since the existing reference redirects to [this page](https://qiagen.my.salesforce-sites.com/KnowledgeBase/KnowledgeNavigatorPage?id=kA4Sc0000000QLtKAM&categoryName=OmicSoft_Suite,OmicSoft_Lands), and it's hard to find actual info regarding MAD at that page.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
