### PR TITLE
Add a warning in the RMD report when some rows are lost after merging Diff and Fatures tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#345](https://github.com/nf-core/differentialabundance/pull/345)] - Plot differentially expressed genes by gene biotype ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst))
 - [[#343](https://github.com/nf-core/differentialabundance/pull/343)] - Add pipeline-level nf-tests ([@atrigila](https://github.com/atrigila), review by [@pinin4fjords](https://github.com/pinin4fjords) and [@nschcolnicov](https://github.com/nschcolnicov))
 - [[#286](https://github.com/nf-core/differentialabundance/pull/286)] - Integration of limma voom for rnaseq data ([@KamilMaliszArdigen](https://github.com/KamilMaliszArdigen), review by [@pinin4fjords](https://github.com/pinin4fjords))
+- [[#354](https://github.com/nf-core/differentialabundance/pull/354)] - Warning message within the R Markdown report to control when genes don't have annotation data ([@alanmmobbs93](https://github.com/alanmmobbs93)). Review by [@WackerO](https://github.com/WackerO) and [@pinin4fjords](https://github.com/pinin4fjords).
 
 ### Fixed
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -399,8 +399,6 @@ results <- lapply(differential_files, function(diff_file) {
 
         # Merge tables
         diff_features <- merge(features, diff, by.x = params$features_id_col, by.y = params$differential_feature_id_column)
-        # test
-        diff_features <- diff_features[1:50,]
 
         # Get number of rows before and after merging
         length_diff <- as.numeric(nrow(diff))

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -370,10 +370,17 @@ differential_files <- lapply(contrasts$id, function(d){
     file.path(params$input_dir, paste0(gsub(' |;', '_', d), differential_file_suffix))
 })
 
-differential_results <- lapply(differential_files, function(diff_file){
-    if (! file.exists(diff_file)){
+# Initialize vector to store warning messages before merging tables
+warnings_list <- c()
+
+# Read differential results and merge with features table
+results <- lapply(differential_files, function(diff_file) {
+    warnings <- c()  # Initialize local warning vector
+
+    if (!file.exists(diff_file)) {
         stop(paste("Differential file", diff_file, "does not exist"))
     }
+
     diff <- read_differential(
         diff_file,
         feature_id_column = params$differential_feature_id_column,
@@ -382,19 +389,43 @@ differential_results <- lapply(differential_files, function(diff_file){
         qval_column = params$differential_qval_column
     )
 
-    # If fold changes are not logged already, log them (we assume they're logged
-    # later on)
-
-    if (! params$differential_foldchanges_logged){
+    # If fold changes are not logged already, log them
+    if (!params$differential_foldchanges_logged) {
         diff[[params$differential_fc_column]] <- log2(diff[[params$differential_fc_column]])
     }
 
     # Annotate differential tables if possible
-    if (! is.null(params$features)){
-        diff <- merge(features, diff, by.x = params$features_id_col, by.y = params$differential_feature_id_column)
+    if (!is.null(params$features)) {
+
+        # Merge tables
+        diff_features <- merge(features, diff, by.x = params$features_id_col, by.y = params$differential_feature_id_column)
+
+        # Get number of rows before and after merging
+        length_diff <- as.numeric(nrow(diff))
+        length_features <- as.numeric(nrow(diff_features))
+
+        # Compare numbers and report
+        if (length_diff != length_features) {
+            warnings <- c(warnings,
+                paste0(
+                    '<p style="color:red;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were lost after merging with features table (', basename(params$features), ').\n',
+                    'Rows in diff table: ', length_diff, '.\n',
+                    'Rows in merged table: ', length_features, '.</p>\n'
+                )
+            )
+        }
+    } else {
+        diff_features <- diff
     }
-    diff
+
+    # Return both the results and the local warnings
+    list(diff_features = diff_features, warnings = warnings)
 })
+
+# Separate differential_results and warnings_list from results
+differential_results <- lapply(results, `[[`, "diff_features")
+warnings_list <- unlist(lapply(results, `[[`, "warnings"))
+
 names(differential_results) <- contrasts$id
 ```
 
@@ -787,7 +818,6 @@ foo <- lapply(names(p_value_types), function(pvt){
 ```
 
 ```{r, echo=FALSE, results='asis', eval = FALSE}
-
 differential_summary_string <- paste(
     paste(
     lapply(
@@ -806,7 +836,13 @@ cat(differential_summary_string)
 
 ### Differential `r params$features_type` details
 
-```{r, echo=FALSE, results='asis'}
+```{r, echo=FALSE, results='asis', warning=FALSE, message=FALSE}
+
+# Display all warnings related to number of rows
+if (length(warnings_list) > 0) {
+    for (warning in warnings_list) { cat(warning) }
+}
+
 for (i in 1:nrow(contrasts)){
     cat("\n#### ", contrast_descriptions[i], "  {.tabset}\n")
 

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -399,6 +399,8 @@ results <- lapply(differential_files, function(diff_file) {
 
         # Merge tables
         diff_features <- merge(features, diff, by.x = params$features_id_col, by.y = params$differential_feature_id_column)
+        # test
+        diff_features <- diff_features[1:50,]
 
         # Get number of rows before and after merging
         length_diff <- as.numeric(nrow(diff))
@@ -408,7 +410,7 @@ results <- lapply(differential_files, function(diff_file) {
         if (length_diff != length_features) {
             warnings <- c(warnings,
                 paste0(
-                    '<p style="color:red;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were lost after merging with features table (', basename(params$features), ').\n',
+                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were lost after merging with features table (', basename(params$features), ').\n',
                     'Rows in diff table: ', length_diff, '.\n',
                     'Rows in merged table: ', length_features, '.</p>\n'
                 )

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -375,11 +375,7 @@ warnings_list <- c()
 
 # Read differential results and merge with features table
 results <- lapply(differential_files, function(diff_file) {
-    warnings <- c()  # Initialize local warning vector
-
-    if (!file.exists(diff_file)) {
-        stop(paste("Differential file", diff_file, "does not exist"))
-    }
+    if (!file.exists(diff_file)) stop(paste("Differential file", diff_file, "does not exist"))
 
     diff <- read_differential(
         diff_file,
@@ -389,65 +385,43 @@ results <- lapply(differential_files, function(diff_file) {
         qval_column = params$differential_qval_column
     )
 
-    # If fold changes are not logged already, log them
+    # Log transform fold changes if not already logged
     if (!params$differential_foldchanges_logged) {
         diff[[params$differential_fc_column]] <- log2(diff[[params$differential_fc_column]])
     }
 
-    # Annotate differential tables if possible
+    # Annotate differential table if features table is provided
     if (!is.null(params$features)) {
+        ## Merge Differential expression table on features table
+        merged <- merge(features, diff, by.x = params$features_id_col, by.y = params$differential_feature_id_column)
 
-        # Merge tables
-        diff_features <- merge(features, diff, by.x = params$features_id_col, by.y = params$differential_feature_id_column)
+        ## Get number of missing rows
+        n_missing <- length(setdiff(diff[[params$differential_feature_id_column]], merged[[params$features_id_col]]))
 
-        # Get number of rows before and after merging
-        rows_diff <- as.numeric(nrow(diff))
-        rows_diff_features <- as.numeric(nrow(diff_features))
-
-        # Check that all IDs were conserved
-        conserved_ids <- all( diff[[params$differential_feature_id_column]] %in% diff_features[[params$features_id_col]] )
-
-        ## Check if all IDs are present
-        if (!conserved_ids) {
-            missing_ids <- setdiff(diff[[params$differential_feature_id_column]], diff_features[[params$features_id_col]])
-            warnings <- c(warnings,
-                paste0(
-                    '<p style="color:#DAA520;"><strong>WARNING:</strong>', length(missing_ids),' IDs from the differential expressed table (', basename(diff_file), ') were absent from the features table (', basename(params$features), ') and lost on merge.\n',
-                    'Missing IDs in diff table: ', paste(missing_ids, collapse = ' '), '.\n',
-                    'Rows in merged table: ', rows_diff_features, '.</p>\n'
-                )
+        ## Create warnings if necessary
+        warnings <- c(
+            ## Missing IDs
+            if (n_missing > 0) sprintf(
+                '<p style="color:#DAA520;"><strong>WARNING:</strong> %d IDs from the differential table (%s) were lost on merge with features table (%s).</p>',
+                n_missing, basename(diff_file), basename(params$features)
+            ),
+            ## Check whether there are fewer rows, missing data
+            if (nrow(merged) < nrow(diff)) sprintf(
+                '<p style="color:#DAA520;"><strong>WARNING:</strong> Rows were lost on merge (%s -> %s). Original: %d, Merged: %d.</p>',
+                basename(diff_file), basename(params$features), nrow(diff), nrow(merged)
+            ),
+            ## Check whether there are more rows, possible duplications
+            if (nrow(merged) > nrow(diff)) sprintf(
+                '<p style="color:#DAA520;"><strong>WARNING:</strong> Rows were duplicated on merge (%s -> %s). Original: %d, Merged: %d.</p>',
+                basename(diff_file), basename(params$features), nrow(diff), nrow(merged)
             )
-        }
-
-        # Compare numbers and report
-        ## Check if features_diff has fewer rows, it would indicate lost of info
-        if ( rows_diff_features < rows_diff ) {
-            warnings <- c(warnings,
-                paste0(
-                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were absent from the features table (', basename(params$features), ') and lost on merge.\n',
-                    'Rows in diff table: ', rows_diff, '.\n',
-                    'Rows in merged table: ', rows_diff_features, '.</p>\n'
-                )
-            )
-        }
-
-        ## Check if features_diff has more rows, it could indicate duplications
-        if ( rows_diff_features > rows_diff ) {
-            warnings <- c(warnings,
-                paste0(
-                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were duplicated on feature table (', basename(params$features), ').\n',
-                    'Rows in diff table: ', rows_diff, '.\n',
-                    'Rows in merged table: ', rows_diff_features, '.</p>\n'
-                )
-            )
-        }
-
+        )
     } else {
-        diff_features <- diff
+        merged <- diff
+        warnings <- character(0)
     }
-
-    # Return both the results and the local warnings
-    list(diff_features = diff_features, warnings = warnings)
+    ## Collect results
+    list(diff_features = merged, warnings = warnings)
 })
 
 # Separate differential_results and warnings_list from results

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -401,19 +401,47 @@ results <- lapply(differential_files, function(diff_file) {
         diff_features <- merge(features, diff, by.x = params$features_id_col, by.y = params$differential_feature_id_column)
 
         # Get number of rows before and after merging
-        length_diff <- as.numeric(nrow(diff))
-        length_features <- as.numeric(nrow(diff_features))
+        rows_diff <- as.numeric(nrow(diff))
+        rows_diff_features <- as.numeric(nrow(diff_features))
 
-        # Compare numbers and report
-        if (length_diff != length_features) {
+        # Check that all IDs were conserved
+        conserved_ids <- all( diff[[params$differential_feature_id_column]] %in% diff_features[[params$features_id_col]] )
+
+        ## Check if all IDs are present
+        if (!conserved_ids) {
+            missing_ids <- setdiff(diff[[params$differential_feature_id_column]], diff_features[[params$features_id_col]])
             warnings <- c(warnings,
                 paste0(
-                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were absent from the features table (', basename(params$features), ') and lost on merge.\n',
-                    'Rows in diff table: ', length_diff, '.\n',
-                    'Rows in merged table: ', length_features, '.</p>\n'
+                    '<p style="color:#DAA520;"><strong>WARNING:</strong>', length(missing_ids),' IDs from the differential expressed table (', basename(diff_file), ') were absent from the features table (', basename(params$features), ') and lost on merge.\n',
+                    'Missing IDs in diff table: ', paste(missing_ids, collapse = ' '), '.\n',
+                    'Rows in merged table: ', rows_diff_features, '.</p>\n'
                 )
             )
         }
+
+        # Compare numbers and report
+        ## Check if features_diff has fewer rows, it would indicate lost of info
+        if ( rows_diff_features < rows_diff ) {
+            warnings <- c(warnings,
+                paste0(
+                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were absent from the features table (', basename(params$features), ') and lost on merge.\n',
+                    'Rows in diff table: ', rows_diff, '.\n',
+                    'Rows in merged table: ', rows_diff_features, '.</p>\n'
+                )
+            )
+        }
+
+        ## Check if features_diff has more rows, it could indicate duplications
+        if ( rows_diff_features > rows_diff ) {
+            warnings <- c(warnings,
+                paste0(
+                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were duplicated on feature table (', basename(params$features), ').\n',
+                    'Rows in diff table: ', rows_diff, '.\n',
+                    'Rows in merged table: ', rows_diff_features, '.</p>\n'
+                )
+            )
+        }
+
     } else {
         diff_features <- diff
     }

--- a/assets/differentialabundance_report.Rmd
+++ b/assets/differentialabundance_report.Rmd
@@ -408,7 +408,7 @@ results <- lapply(differential_files, function(diff_file) {
         if (length_diff != length_features) {
             warnings <- c(warnings,
                 paste0(
-                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were lost after merging with features table (', basename(params$features), ').\n',
+                    '<p style="color:#DAA520;"><strong>WARNING:</strong> Some rows from the differential expressed table (', basename(diff_file), ') were absent from the features table (', basename(params$features), ') and lost on merge.\n',
                     'Rows in diff table: ', length_diff, '.\n',
                     'Rows in merged table: ', length_features, '.</p>\n'
                 )


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

# PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] `CHANGELOG.md` is updated.

# Issue reported:

On [#340](https://github.com/nf-core/differentialabundance/issues/340) it was reported that many genes were lost in the volcano plot generated by the R Markdown report, but that the PNG file was correct. These genes get lost if the annotation table doesn't contain them, resulting in reduced plots and results in this last part. As mentioned by the user, big discrepancies can be easily catched, but the small ones can go unnoticed, ending up in undesired results.

So, a warning message was added if the annotated differential expressed table contains fewer rows. Other solutions can be:
- Retain all rows even if there's no data about these genes.
- Report the error and stop the pipeline (I believe this should be done as an early validation when starting the pipeline).

