### PR TITLE
Fix: Quote shell parameters

### DIFF
--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -38,13 +38,13 @@ process SHINYNGS_APP {
 
     """
     make_app_from_files.R \\
-        --sample_metadata $sample \\
-        --feature_metadata $feature_meta \\
-        --assay_files ${assay_files.join(',')} \\
-        --contrast_file $contrasts \\
-        --contrast_stats_assay $contrast_stats_assay \\
-        --differential_results ${differential_results.join(',')} \\
-        --output_dir $prefix \\
+        --sample_metadata "$sample" \\
+        --feature_metadata "$feature_meta" \\
+        --assay_files "${assay_files.join(',')}" \\
+        --contrast_file "$contrasts" \\
+        --contrast_stats_assay "$contrast_stats_assay" \\
+        --differential_results "${differential_results.join(',')}" \\
+        --output_dir "$prefix" \\
         $args \\
 
     cat <<-END_VERSIONS > versions.yml
@@ -58,9 +58,9 @@ process SHINYNGS_APP {
     def prefix = task.ext.prefix ?: meta.id
 
     """
-    mkdir -p $prefix
-    touch ${prefix}/data.rds
-    touch ${prefix}/app.R
+    mkdir -p "$prefix"
+    touch "${prefix}/data.rds"
+    touch "${prefix}/app.R"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
I ran a differential abundance pipeline with a study name that had spaces in it, and the pipeline crashed because the `make_app_from_files.R` caller script was not escaping parameters as expected. I believe the patch included in this PR is pretty easy to follow: The parameters were expanded by the `$` and the second word of the study name was interpreted as another argument.

Making this change made the pipeline succeed.

If you believe this contribution is of your interest but you require of me to add tests I can try to find time to learn how to write tests and comply with the rest of the checklist. It may take me a while though to find the time, and the patch is really minor so I would appreciate your consideration.

You may want to consider security ramifications of being able to pass a study_name like `; arbitrary_command` and inject code that would be executed by the pipeline. I am not familiar enough with nextflow to understand whether that should be considered a vulnerability risk or not, but if you think this is an issue, then this PR would fix it.

In any case, thanks for your time and for all the work you do. 

Looking forward to getting more involved!

<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
