### PR TITLE
Improve formula regex to match random effects and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [[#527](https://github.com/nf-core/differentialabundance/pull/513)] - Fix contrast schema to allow for random effects and other advanced formula features. ([@grst](https://github.com/grst), review by [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#513](https://github.com/nf-core/differentialabundance/pull/513)] - Fix contrast schema to allow for zero-intercept models. ([@grst](https://github.com/grst), review by [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#476](https://github.com/nf-core/differentialabundance/pull/476)] - Fixed null.csv and warning at top of report ([@SusiJo](https://github.com/SusiJo), reviewed by [@pinin4fjords](https://github.com/pinin4fjords), [@atrigila](https://github.com/atrigila), [@maxulysse](https://github.com/maxulysse))
 - [[#358](https://github.com/nf-core/differentialabundance/pull/358)] - Fixed nf-tests not running due to `--changed-since HEAD^`([@atrigila](https://github.com/atrigila), review by [@pinin4fjords](https://github.com/pinin4fjords))

--- a/assets/schema_contrasts.json
+++ b/assets/schema_contrasts.json
@@ -36,16 +36,12 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "id"
-                ],
+                "required": ["id"],
                 "additionalProperties": false
             },
             "minItems": 1
         }
     },
-    "required": [
-        "contrasts"
-    ],
+    "required": ["contrasts"],
     "additionalProperties": false
 }

--- a/assets/schema_contrasts.json
+++ b/assets/schema_contrasts.json
@@ -15,7 +15,7 @@
                     },
                     "formula": {
                         "type": "string",
-                        "pattern": "^~\\s*(?:[A-Za-z0-9_]+(?:\\s*(?:[:+*])\\s*[A-Za-z0-9_]+)*)?(?:\\s*-\\s*1)?$"
+                        "pattern": "^~\\s*(?:(?:[A-Za-z0-9_.]+(?:\\([^)]*\\))?|\\([^)]*\\))(?:\\s*[+*:|\\/-]\\s*(?:[A-Za-z0-9_.]+(?:\\([^)]*\\))?|\\([^)]*\\)))*)?(?:\\s*-\\s*1)?$"
                     },
                     "comparison": {
                         "type": "array",
@@ -36,12 +36,16 @@
                         "type": "string"
                     }
                 },
-                "required": ["id"],
+                "required": [
+                    "id"
+                ],
                 "additionalProperties": false
             },
             "minItems": 1
         }
     },
-    "required": ["contrasts"],
+    "required": [
+        "contrasts"
+    ],
     "additionalProperties": false
 }


### PR DESCRIPTION
Turns out #513 was not enough, we didn't think of random effects, e.g. `~ treatment + (1 | patient)`. 
Also, in theory it's possible to specify functions, e.g. `log(var)` directly in the formula. 

I asked Claude to generate a regex to match all wilkinson formulae, and this is what it came up with. 
Here's a regex101 and it now matches all positive examples and detects *almost* all negative examples: https://regex101.com/r/jXGZ1g/1

I don't think we'll get much further than that with a regex (matching open/closed brackets is not possible with a regular language). 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
