### PR TITLE
Fix default parameters for limma/dream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#603](https://github.com/nf-core/differentialabundance/pull/603/)] - Update default parameters for limma and dream: use `voom` by default and treat corresponding normalised matrix as already log-transformed, review by [@pinin4fjords](https://github.com/pinin4fjords).
 - [[#581](https://github.com/nf-core/differentialabundance/pull/581)] - Update all modules and subworkflows, allowing differential analysis with numeric sample IDs ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila), [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#576](https://github.com/nf-core/differentialabundance/pull/576)] - Autoformat differential abundance report ([@delfiterradas](https://github.com/delfiterradas), review by [@pinin4fjords](https://github.com/pinin4fjords) and [@grst](https://github.com/grst)).
 - [[#569](https://github.com/nf-core/differentialabundance/pull/569)] - Update shinyngs modules with fix in validator to allow using only fomula contrasts ([@delfiterradas](https://github.com/delfiterradas), review by [@pinin4fjords](https://github.com/pinin4fjords) and [@grst](https://github.com/grst)).

--- a/conf/paramsheet.yaml
+++ b/conf/paramsheet.yaml
@@ -63,6 +63,7 @@
 - paramset_name: dream_rnaseq
   include: paramsheet/rnaseq
   differential_method: dream
+  dream_use_voom: true
 
   exploratory_assay_names: raw,normalised
   exploratory_final_assay: normalised

--- a/conf/paramsheet.yaml
+++ b/conf/paramsheet.yaml
@@ -41,7 +41,7 @@
 
   exploratory_assay_names: raw,normalised
   exploratory_final_assay: normalised
-  exploratory_log2_assays: raw,normalised
+  exploratory_log2_assays: raw
 
   differential_file_suffix: ".limma.results.tsv"
   differential_fc_column: logFC
@@ -67,7 +67,7 @@
 
   exploratory_assay_names: raw,normalised
   exploratory_final_assay: normalised
-  exploratory_log2_assays: raw,normalised
+  exploratory_log2_assays: raw
 
   differential_file_suffix: ".dream.results.tsv"
   differential_fc_column: logFC


### PR DESCRIPTION
When running on count data, dream should use voom by default, as limma does.

<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
