### PR TITLE
Fix parameter priority in multi-config setup

### DIFF
--- a/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
@@ -399,7 +399,8 @@ def getParamsheetConfigurations() {
         .collect{ row ->
             // Note that the paramsheet may not contain all the parameters
             // defined in the pipeline, so we need to merge them
-            def fullparamset = params + row
+            // Priority: command line params > paramsheet > defaults
+            def fullparamset = row + params
             return fullparamset
         }
 }


### PR DESCRIPTION
## Summary
This PR fixes issue #472 by correcting the parameter priority in multi-config setups.

## Changes
- Changed parameter merging order from `params + row` to `row + params` in `getParamsheetConfigurations()`
- This ensures command line flags have priority over paramsheet values
- Priority order is now: **command line flags > paramsheet > defaults**

## Related Issue
Fixes #472

## Testing
- Pre-commit hooks passed successfully
- CI tests will run automatically

The fix is simple and logical: reversing the order of map merging in Groovy to ensure that command-line parameters (which come from `params`) override values from the paramsheet (`row`).