### PR TITLE
Change `round_digits` default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#681](https://github.com/nf-core/differentialabundance/pull/681)] - Remove the nextflow config default `--round_digits 4` parameter and change it for `-1` ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#646](https://github.com/nf-core/differentialabundance/pull/646)] - Remove the `--differential_feature_name_column` parameter and consolidate its functionality into `--features_name_col` ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#659](https://github.com/nf-core/differentialabundance/pull/659)] - Remove `immunedeconv` module ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#644](https://github.com/nf-core/differentialabundance/pull/644)] - Reverted back to use profiles by default, and use paramsheet only when provided, ([@suzannejin](https://github.com/suzannejin)), review by [@pinin4fjords](https://github.com/pinin4fjords) and [@grst](https://github.com/grst).

--- a/conf/test/affy/affy_limma_gprofiler2.config
+++ b/conf/test/affy/affy_limma_gprofiler2.config
@@ -25,6 +25,7 @@ params {
     differential_max_pval        = 0.05
     differential_max_qval        = 0.05
     differential_min_fold_change = 1.5
+    round_digits                 = 4
 
     // gprofiler2
     gprofiler2_organism = 'mmusculus'

--- a/conf/test/affy/affy_limma_gsea.config
+++ b/conf/test/affy/affy_limma_gsea.config
@@ -25,6 +25,7 @@ params {
     differential_max_pval        = 0.05
     differential_max_qval        = 0.05
     differential_min_fold_change = 1.5
+    round_digits                 = 4
 
     // GSEA
     gsea_rnd_seed = '10'

--- a/conf/test/maxquant/maxquant.config
+++ b/conf/test/maxquant/maxquant.config
@@ -24,4 +24,5 @@ params {
 
     // Proteus
     proteus_measurecol_prefix = 'LFQ intensity'
+    round_digits              = 4
 }

--- a/conf/test/rnaseq/rnaseq_nogtf.config
+++ b/conf/test/rnaseq/rnaseq_nogtf.config
@@ -27,4 +27,5 @@ params {
 
     // Apply a higher filter to check that the filtering works
     filtering_min_abundance = 10
+    round_digits            = 4
 }

--- a/conf/test/soft/soft.config
+++ b/conf/test/soft/soft.config
@@ -16,4 +16,5 @@ includeConfig '../../testdata/soft.config'
 params {
     config_profile_name        = 'Test soft profile'
     config_profile_description = 'SOFT test dataset to check pipeline function'
+    round_digits               = 4
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -561,6 +561,7 @@ work                # Directory containing the nextflow working files
 
 - If you don't like the colors used in the report, try a different `RColorBrewer` palette by changing the `exploratory_palette_name` and/or `differential_palette_name` parameters.
 - In rare cases, some users have reported issues with DESeq2 using all available cores on a machine, rather than those specified in the process configuration. This can be prevented by setting the `OPENBLAS_NUM_THREADS` environment variable.
+- By default, `--round_digits` is disabled (`-1`) to avoid unintentional information loss in small numeric values. Enable it only when you explicitly want rounded report tables.
 
 ### Scaling up to large sample numbers
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,7 @@ params {
 
     // Output options
     outdir                     = null
-    round_digits               = 4
+    round_digits               = -1
 
     // Paramsheet options
     paramset_name              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -62,7 +62,7 @@
                 },
                 "round_digits": {
                     "type": "integer",
-                    "default": 4,
+                    "default": -1,
                     "description": "To how many digits should numeric output in different modules be rounded? If -1 or null, will not round.",
                     "help_text": "This affects output from the following modules (both their tabular output and their result sections in the report): proteus, limma, deseq2, gprofiler2."
                 }


### PR DESCRIPTION
For: https://github.com/nf-core/differentialabundance/issues/657

- Rounding now only happens in the tests, not by default.