### PR TITLE
Emit individual channels from inner workflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -52,13 +52,95 @@ workflow NFCORE_DIFFERENTIALABUNDANCE {
     )
 
     emit:
-    preprocessing = DIFFERENTIALABUNDANCE.out.preprocessing
-    differential  = DIFFERENTIALABUNDANCE.out.differential
-    functional    = DIFFERENTIALABUNDANCE.out.functional
-    plotting      = DIFFERENTIALABUNDANCE.out.plotting
-    shinyngs      = DIFFERENTIALABUNDANCE.out.shinyngs
-    report        = DIFFERENTIALABUNDANCE.out.report
-    versions      = DIFFERENTIALABUNDANCE.out.versions
+
+    // Preprocessing: Affy
+    affy_cel_files             = DIFFERENTIALABUNDANCE.out.affy_cel_files
+    affy_raw_expression        = DIFFERENTIALABUNDANCE.out.affy_raw_expression
+    affy_norm_expression       = DIFFERENTIALABUNDANCE.out.affy_norm_expression
+    affy_annotation            = DIFFERENTIALABUNDANCE.out.affy_annotation
+    affy_raw_rds               = DIFFERENTIALABUNDANCE.out.affy_raw_rds
+
+    // Preprocessing: Proteus
+    proteus_raw                = DIFFERENTIALABUNDANCE.out.proteus_raw
+    proteus_norm               = DIFFERENTIALABUNDANCE.out.proteus_norm
+    proteus_plots              = DIFFERENTIALABUNDANCE.out.proteus_plots
+    proteus_raw_rdata          = DIFFERENTIALABUNDANCE.out.proteus_raw_rdata
+    proteus_norm_rdata         = DIFFERENTIALABUNDANCE.out.proteus_norm_rdata
+    proteus_session_info       = DIFFERENTIALABUNDANCE.out.proteus_session_info
+
+    // Preprocessing: GEO
+    geo_expression             = DIFFERENTIALABUNDANCE.out.geo_expression
+    geo_annotation             = DIFFERENTIALABUNDANCE.out.geo_annotation
+    geo_rds                    = DIFFERENTIALABUNDANCE.out.geo_rds
+
+    // Preprocessing: GTF
+    gtf_annotation             = DIFFERENTIALABUNDANCE.out.gtf_annotation
+
+    // Differential
+    diff_results               = DIFFERENTIALABUNDANCE.out.diff_results
+    diff_results_filtered      = DIFFERENTIALABUNDANCE.out.diff_results_filtered
+    diff_normalised_matrix     = DIFFERENTIALABUNDANCE.out.diff_normalised_matrix
+    diff_variance_stabilised   = DIFFERENTIALABUNDANCE.out.diff_variance_stabilised
+    diff_size_factors          = DIFFERENTIALABUNDANCE.out.diff_size_factors
+    diff_dispersion_plot       = DIFFERENTIALABUNDANCE.out.diff_dispersion_plot
+    diff_md_plot               = DIFFERENTIALABUNDANCE.out.diff_md_plot
+    diff_rdata                 = DIFFERENTIALABUNDANCE.out.diff_rdata
+    diff_session_info          = DIFFERENTIALABUNDANCE.out.diff_session_info
+    diff_annotated             = DIFFERENTIALABUNDANCE.out.diff_annotated
+
+    // Functional: GSEA
+    gsea_report_tsv            = DIFFERENTIALABUNDANCE.out.gsea_report_tsv
+    gsea_report_html           = DIFFERENTIALABUNDANCE.out.gsea_report_html
+    gsea_index_html            = DIFFERENTIALABUNDANCE.out.gsea_index_html
+    gsea_heat_map_corr_plot    = DIFFERENTIALABUNDANCE.out.gsea_heat_map_corr_plot
+    gsea_ranked_gene_list      = DIFFERENTIALABUNDANCE.out.gsea_ranked_gene_list
+    gsea_gene_set_sizes        = DIFFERENTIALABUNDANCE.out.gsea_gene_set_sizes
+    gsea_histogram             = DIFFERENTIALABUNDANCE.out.gsea_histogram
+    gsea_heatmap               = DIFFERENTIALABUNDANCE.out.gsea_heatmap
+    gsea_pvalues_vs_nes_plot   = DIFFERENTIALABUNDANCE.out.gsea_pvalues_vs_nes_plot
+    gsea_ranked_list_corr      = DIFFERENTIALABUNDANCE.out.gsea_ranked_list_corr
+    gsea_butterfly_plot        = DIFFERENTIALABUNDANCE.out.gsea_butterfly_plot
+    gsea_gene_set_tsv          = DIFFERENTIALABUNDANCE.out.gsea_gene_set_tsv
+    gsea_gene_set_html         = DIFFERENTIALABUNDANCE.out.gsea_gene_set_html
+    gsea_gene_set_heatmap      = DIFFERENTIALABUNDANCE.out.gsea_gene_set_heatmap
+    gsea_gene_set_enplot       = DIFFERENTIALABUNDANCE.out.gsea_gene_set_enplot
+    gsea_gene_set_dist         = DIFFERENTIALABUNDANCE.out.gsea_gene_set_dist
+    gsea_snapshot              = DIFFERENTIALABUNDANCE.out.gsea_snapshot
+    gsea_archive               = DIFFERENTIALABUNDANCE.out.gsea_archive
+    gsea_rpt                   = DIFFERENTIALABUNDANCE.out.gsea_rpt
+
+    // Functional: gprofiler2
+    gprofiler2_html            = DIFFERENTIALABUNDANCE.out.gprofiler2_html
+    gprofiler2_all_enrichment  = DIFFERENTIALABUNDANCE.out.gprofiler2_all_enrichment
+    gprofiler2_sub_enrichment  = DIFFERENTIALABUNDANCE.out.gprofiler2_sub_enrichment
+    gprofiler2_plot_png        = DIFFERENTIALABUNDANCE.out.gprofiler2_plot_png
+    gprofiler2_sub_plot        = DIFFERENTIALABUNDANCE.out.gprofiler2_sub_plot
+    gprofiler2_rds             = DIFFERENTIALABUNDANCE.out.gprofiler2_rds
+    gprofiler2_filtered_gmt    = DIFFERENTIALABUNDANCE.out.gprofiler2_filtered_gmt
+
+    // Functional: decoupler
+    decoupler_estimate         = DIFFERENTIALABUNDANCE.out.decoupler_estimate
+    decoupler_pvals            = DIFFERENTIALABUNDANCE.out.decoupler_pvals
+    decoupler_png              = DIFFERENTIALABUNDANCE.out.decoupler_png
+
+    // Functional: common
+    functional_session_info    = DIFFERENTIALABUNDANCE.out.functional_session_info
+
+    // Plotting
+    plot_exploratory           = DIFFERENTIALABUNDANCE.out.plot_exploratory
+    plot_volcanos              = DIFFERENTIALABUNDANCE.out.plot_volcanos
+
+    // ShinyNGS
+    shinyngs_data              = DIFFERENTIALABUNDANCE.out.shinyngs_data
+    shinyngs_app_file          = DIFFERENTIALABUNDANCE.out.shinyngs_app_file
+
+    // Report
+    report_html                = DIFFERENTIALABUNDANCE.out.report_html
+    report_bundle              = DIFFERENTIALABUNDANCE.out.report_bundle
+
+    // Versions
+    nfcore_versions            = DIFFERENTIALABUNDANCE.out.nfcore_versions
+    collated_versions          = DIFFERENTIALABUNDANCE.out.collated_versions
 }
 
 /*
@@ -106,14 +188,89 @@ workflow {
         params.hook_url,
     )
 
+    //
+    // Build category channels for publishing (name-tagging happens here)
+    //
+    def out = NFCORE_DIFFERENTIALABUNDANCE.out
+
+    ch_pub_preprocessing = out.affy_cel_files.map { it -> ['affy_cel_files', it[0], it[1..-1]] }
+        .mix(out.affy_raw_expression.map        { meta, file -> ['affy_raw_expression', meta, file] })
+        .mix(out.affy_norm_expression.map       { meta, file -> ['affy_norm_expression', meta, file] })
+        .mix(out.affy_annotation.map            { meta, file -> ['affy_annotation', meta, file] })
+        .mix(out.affy_raw_rds.map               { meta, file -> ['affy_raw_rds', meta, file] })
+        .mix(out.proteus_raw.map                { meta, file -> ['proteus_raw', meta, file] })
+        .mix(out.proteus_norm.map               { meta, file -> ['proteus_norm', meta, file] })
+        .mix(out.proteus_plots.map              { meta, file -> ['proteus_plots', meta, file] })
+        .mix(out.proteus_raw_rdata.map          { meta, file -> ['proteus_raw_rdata', meta, file] })
+        .mix(out.proteus_norm_rdata.map         { meta, file -> ['proteus_norm_rdata', meta, file] })
+        .mix(out.proteus_session_info.map       { meta, file -> ['proteus_session_info', meta, file] })
+        .mix(out.geo_expression.map             { meta, file -> ['geo_expression', meta, file] })
+        .mix(out.geo_annotation.map             { meta, file -> ['geo_annotation', meta, file] })
+        .mix(out.geo_rds.map                    { meta, file -> ['geo_rds', meta, file] })
+        .mix(out.gtf_annotation.map             { meta, file -> ['gtf_annotation', meta, file] })
+
+    ch_pub_differential = out.diff_results.map              { _key, meta, file -> ['results', meta, file] }
+        .mix(out.diff_results_filtered.map  { _key, meta, file -> ['results_filtered', meta, file] })
+        .mix(out.diff_normalised_matrix.map { meta, file -> ['normalised_matrix', meta, file] })
+        .mix(out.diff_variance_stabilised.map { meta, file -> ['variance_stabilised_matrix', meta, file] })
+        .mix(out.diff_size_factors.map      { meta, file -> ['size_factors', meta, file] })
+        .mix(out.diff_dispersion_plot.map   { meta, file -> ['dispersion_plot', meta, file] })
+        .mix(out.diff_md_plot.map           { meta, file -> ['md_plot', meta, file] })
+        .mix(out.diff_rdata.map             { meta, file -> ['rdata', meta, file] })
+        .mix(out.diff_session_info.map      { meta, file -> ['session_info', meta, file] })
+        .mix(out.diff_annotated.map         { meta, file -> ['annotated', meta, file] })
+
+    ch_pub_functional = out.gsea_report_tsv.map          { meta, ref, target -> ['gsea_report_tsv', meta, [ref, target]] }
+        .mix(out.gsea_report_html.map       { meta, ref, target -> ['gsea_report_html', meta, [ref, target]] })
+        .mix(out.gsea_index_html.map        { meta, file -> ['gsea_index_html', meta, file] })
+        .mix(out.gsea_heat_map_corr_plot.map { meta, file -> ['gsea_heat_map_corr_plot', meta, file] })
+        .mix(out.gsea_ranked_gene_list.map  { meta, file -> ['gsea_ranked_gene_list', meta, file] })
+        .mix(out.gsea_gene_set_sizes.map    { meta, file -> ['gsea_gene_set_sizes', meta, file] })
+        .mix(out.gsea_histogram.map         { meta, file -> ['gsea_histogram', meta, file] })
+        .mix(out.gsea_heatmap.map           { meta, file -> ['gsea_heatmap', meta, file] })
+        .mix(out.gsea_pvalues_vs_nes_plot.map { meta, file -> ['gsea_pvalues_vs_nes_plot', meta, file] })
+        .mix(out.gsea_ranked_list_corr.map  { meta, file -> ['gsea_ranked_list_corr', meta, file] })
+        .mix(out.gsea_butterfly_plot.map    { meta, file -> ['gsea_butterfly_plot', meta, file] })
+        .mix(out.gsea_gene_set_tsv.map      { meta, file -> ['gsea_gene_set_tsv', meta, file] })
+        .mix(out.gsea_gene_set_html.map     { meta, file -> ['gsea_gene_set_html', meta, file] })
+        .mix(out.gsea_gene_set_heatmap.map  { meta, file -> ['gsea_gene_set_heatmap', meta, file] })
+        .mix(out.gsea_gene_set_enplot.map   { meta, file -> ['gsea_gene_set_enplot', meta, file] })
+        .mix(out.gsea_gene_set_dist.map     { meta, file -> ['gsea_gene_set_dist', meta, file] })
+        .mix(out.gsea_snapshot.map          { meta, file -> ['gsea_snapshot', meta, file] })
+        .mix(out.gsea_archive.map           { meta, file -> ['gsea_archive', meta, file] })
+        .mix(out.gsea_rpt.map               { meta, file -> ['gsea_rpt', meta, file] })
+        .mix(out.gprofiler2_html.map        { meta, file -> ['gprofiler2_html', meta, file] })
+        .mix(out.gprofiler2_all_enrichment.map { meta, file -> ['gprofiler2_all_enrichment', meta, file] })
+        .mix(out.gprofiler2_sub_enrichment.map { meta, file -> ['gprofiler2_sub_enrichment', meta, file] })
+        .mix(out.gprofiler2_plot_png.map    { meta, file -> ['gprofiler2_plot_png', meta, file] })
+        .mix(out.gprofiler2_sub_plot.map    { meta, file -> ['gprofiler2_sub_plot', meta, file] })
+        .mix(out.gprofiler2_rds.map         { meta, file -> ['gprofiler2_rds', meta, file] })
+        .mix(out.gprofiler2_filtered_gmt.map { meta, file -> ['gprofiler2_filtered_gmt', meta, file] })
+        .mix(out.decoupler_estimate.map     { meta, file -> ['decoupler_estimate', meta, file] })
+        .mix(out.decoupler_pvals.map        { meta, file -> ['decoupler_pvals', meta, file] })
+        .mix(out.decoupler_png.map          { meta, file -> ['decoupler_png', meta, file] })
+        .mix(out.functional_session_info.map { meta, file -> ['session_info', meta, file] })
+
+    ch_pub_plotting = out.plot_exploratory.map { meta, file -> ['exploratory', meta, file] }
+        .mix(out.plot_volcanos.map          { meta, file -> ['differential_volcanos', meta, file] })
+
+    ch_pub_shinyngs = out.shinyngs_data.map { meta, file -> ['shinyngs_data', meta, file] }
+        .mix(out.shinyngs_app_file.map      { meta, file -> ['shinyngs_app', meta, file] })
+
+    ch_pub_report = out.report_html.map { meta, file -> ['report_html', meta, file] }
+        .mix(out.report_bundle.map          { meta, file -> ['report_bundle', meta, file] })
+
+    ch_pub_versions = out.nfcore_versions.map { file -> ['versions', [:], file] }
+        .mix(out.collated_versions.map      { file -> ['collated_versions', [:], file] })
+
     publish:
-    preprocessing = NFCORE_DIFFERENTIALABUNDANCE.out.preprocessing
-    differential  = NFCORE_DIFFERENTIALABUNDANCE.out.differential
-    functional    = NFCORE_DIFFERENTIALABUNDANCE.out.functional
-    plotting      = NFCORE_DIFFERENTIALABUNDANCE.out.plotting
-    shinyngs      = NFCORE_DIFFERENTIALABUNDANCE.out.shinyngs
-    report        = NFCORE_DIFFERENTIALABUNDANCE.out.report
-    versions      = NFCORE_DIFFERENTIALABUNDANCE.out.versions
+    preprocessing = ch_pub_preprocessing
+    differential  = ch_pub_differential
+    functional    = ch_pub_functional
+    plotting      = ch_pub_plotting
+    shinyngs      = ch_pub_shinyngs
+    report        = ch_pub_report
+    versions      = ch_pub_versions
 }
 
 output {

--- a/workflows/differentialabundance.nf
+++ b/workflows/differentialabundance.nf
@@ -189,8 +189,6 @@ workflow DIFFERENTIALABUNDANCE {
     ch_affy_norm = prepareModuleOutput(AFFY_JUSTRMA_NORM.out.expression, ch_paramsets)
     ch_affy_platform_features = prepareModuleOutput(AFFY_JUSTRMA_RAW.out.annotation, ch_paramsets)
 
-    ch_affy_raw_rds = prepareModuleOutput(AFFY_JUSTRMA_RAW.out.rds, ch_paramsets)
-
     ch_versions = ch_versions
         .mix(AFFY_JUSTRMA_RAW.out.versions)
 
@@ -226,10 +224,6 @@ workflow DIFFERENTIALABUNDANCE {
             .mix(PROTEUS.out.norm_dist_plot)
         , ch_paramsets // here we keep contrast, as the plots are different across contrasts, and we can use it for output folder naming later
     )
-    ch_proteus_raw_rdata    = prepareModuleOutput(PROTEUS.out.raw_rdata, ch_paramsets)
-    ch_proteus_norm_rdata   = prepareModuleOutput(PROTEUS.out.norm_rdata, ch_paramsets)
-    ch_proteus_session_info = prepareModuleOutput(PROTEUS.out.session_info, ch_paramsets)
-
     ch_versions = ch_versions.mix(PROTEUS.out.versions)
 
     //
@@ -241,8 +235,6 @@ workflow DIFFERENTIALABUNDANCE {
 
     ch_soft_norm = prepareModuleOutput(GEOQUERY_GETGEO.out.expression, ch_paramsets)
     ch_soft_features = prepareModuleOutput(GEOQUERY_GETGEO.out.annotation, ch_paramsets)
-
-    ch_geo_rds = prepareModuleOutput(GEOQUERY_GETGEO.out.rds, ch_paramsets)
 
     ch_versions = ch_versions
         .mix(GEOQUERY_GETGEO.out.versions)
@@ -506,12 +498,6 @@ workflow DIFFERENTIALABUNDANCE {
     ch_differential_norm = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.normalised_matrix, ch_paramsets, meta_keys_to_remove=['differential_method']) // meta, norm file
     ch_differential_varstab = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.variance_stabilised_matrix, ch_paramsets, meta_keys_to_remove=['differential_method']) // meta, varstab file
 
-    ch_diff_size_factors    = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.size_factors, ch_paramsets)
-    ch_diff_dispersion_plot = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.dispersion_plot, ch_paramsets)
-    ch_diff_md_plot         = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.md_plot, ch_paramsets)
-    ch_diff_rdata           = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.rdata, ch_paramsets)
-    ch_diff_session_info    = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.session_info, ch_paramsets)
-
     ch_versions = ch_versions
         .mix(ABUNDANCE_DIFFERENTIAL_FILTER.out.versions)
 
@@ -538,8 +524,6 @@ workflow DIFFERENTIALABUNDANCE {
     CSVTK_JOIN(
         prepareModuleInput(ch_final_annotation_input, 'differential')
     )
-
-    ch_diff_annotated = prepareModuleOutput(CSVTK_JOIN.out.csv, ch_paramsets)
 
     ch_versions = ch_versions
         .mix(CSVTK_JOIN.out.versions)
@@ -646,38 +630,6 @@ workflow DIFFERENTIALABUNDANCE {
     // by setting 'use_meta_key' to true. This will facilitate later on to join/combine channels.
     ch_functional_results = prepareModuleOutput(ch_functional_results, ch_paramsets, meta_keys_to_remove=['functional_method'], use_meta_key=true) // key, meta, [ functional results ]
 
-    // Prepare functional outputs for individual emission
-    ch_gsea_report_tsv            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_tsv, ch_paramsets)
-    ch_gsea_report_html           = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_html, ch_paramsets)
-    ch_gsea_index_html            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_index_html, ch_paramsets)
-    ch_gsea_heat_map_corr_plot    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heat_map_corr_plot, ch_paramsets)
-    ch_gsea_ranked_gene_list      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_gene_list, ch_paramsets)
-    ch_gsea_gene_set_sizes        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_sizes, ch_paramsets)
-    ch_gsea_histogram             = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_histogram, ch_paramsets)
-    ch_gsea_heatmap               = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heatmap, ch_paramsets)
-    ch_gsea_pvalues_vs_nes_plot   = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_pvalues_vs_nes_plot, ch_paramsets)
-    ch_gsea_ranked_list_corr      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_list_corr, ch_paramsets)
-    ch_gsea_butterfly_plot        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_butterfly_plot, ch_paramsets)
-    ch_gsea_gene_set_tsv          = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_tsv, ch_paramsets)
-    ch_gsea_gene_set_html         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_html, ch_paramsets)
-    ch_gsea_gene_set_heatmap      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_heatmap, ch_paramsets)
-    ch_gsea_gene_set_enplot       = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_enplot, ch_paramsets)
-    ch_gsea_gene_set_dist         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_dist, ch_paramsets)
-    ch_gsea_snapshot              = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_snapshot, ch_paramsets)
-    ch_gsea_archive               = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_archive, ch_paramsets)
-    ch_gsea_rpt                   = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_rpt, ch_paramsets)
-    ch_gprofiler2_html            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_plot_html, ch_paramsets)
-    ch_gprofiler2_all_enrichment  = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_all_enrich, ch_paramsets)
-    ch_gprofiler2_sub_enrichment  = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_enrich, ch_paramsets)
-    ch_gprofiler2_plot_png        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_artifacts, ch_paramsets)
-    ch_gprofiler2_sub_plot        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_plot, ch_paramsets)
-    ch_gprofiler2_rds             = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_rds, ch_paramsets)
-    ch_gprofiler2_filtered_gmt    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_filtered_gmt, ch_paramsets)
-    ch_decoupler_estimate         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_estimate, ch_paramsets)
-    ch_decoupler_pvals            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_pvals, ch_paramsets)
-    ch_decoupler_png              = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_png, ch_paramsets)
-    ch_functional_session_info    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.session_info, ch_paramsets)
-
     ch_versions = ch_versions
         .mix(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.versions)
 
@@ -723,16 +675,6 @@ workflow DIFFERENTIALABUNDANCE {
         prepareModuleInput(ch_exploratory_input, 'exploratory')
     )
 
-    ch_plots_exploratory = prepareModuleOutput(
-        PLOT_EXPLORATORY.out.boxplots_png
-            .mix(PLOT_EXPLORATORY.out.densities_png)
-            .mix(PLOT_EXPLORATORY.out.pca2d_png)
-            .mix(PLOT_EXPLORATORY.out.pca3d_png)
-            .mix(PLOT_EXPLORATORY.out.mad_png)
-            .mix(PLOT_EXPLORATORY.out.dendro),
-        ch_paramsets
-    )
-
     // Plot differential analysis results
 
     ch_plot_differential_input = ch_differential_results  // [meta, meta with contrast, results]
@@ -750,8 +692,6 @@ workflow DIFFERENTIALABUNDANCE {
         ch_plot_differential_input.differential_results,
         ch_plot_differential_input.samples_features_matrices
     )
-
-    ch_plots_volcanos = prepareModuleOutput(PLOT_DIFFERENTIAL.out.volcanos_png, ch_paramsets)
 
     // Gather software versions
 
@@ -998,20 +938,20 @@ workflow DIFFERENTIALABUNDANCE {
     affy_raw_expression        = ch_affy_raw
     affy_norm_expression       = ch_affy_norm
     affy_annotation            = ch_affy_platform_features
-    affy_raw_rds               = ch_affy_raw_rds
+    affy_raw_rds               = prepareModuleOutput(AFFY_JUSTRMA_RAW.out.rds, ch_paramsets)
 
     // --- Preprocessing: Proteus ---
     proteus_raw                = ch_proteus_raw
     proteus_norm               = ch_proteus_norm
     proteus_plots              = ch_proteus_plots
-    proteus_raw_rdata          = ch_proteus_raw_rdata
-    proteus_norm_rdata         = ch_proteus_norm_rdata
-    proteus_session_info       = ch_proteus_session_info
+    proteus_raw_rdata          = prepareModuleOutput(PROTEUS.out.raw_rdata, ch_paramsets)
+    proteus_norm_rdata         = prepareModuleOutput(PROTEUS.out.norm_rdata, ch_paramsets)
+    proteus_session_info       = prepareModuleOutput(PROTEUS.out.session_info, ch_paramsets)
 
     // --- Preprocessing: GEO ---
     geo_expression             = ch_soft_norm
     geo_annotation             = ch_soft_features
-    geo_rds                    = ch_geo_rds
+    geo_rds                    = prepareModuleOutput(GEOQUERY_GETGEO.out.rds, ch_paramsets)
 
     // --- Preprocessing: GTF ---
     gtf_annotation             = ch_gtf_features
@@ -1021,54 +961,62 @@ workflow DIFFERENTIALABUNDANCE {
     diff_results_filtered      = ch_differential_results_filtered
     diff_normalised_matrix     = ch_differential_norm
     diff_variance_stabilised   = ch_differential_varstab
-    diff_size_factors          = ch_diff_size_factors
-    diff_dispersion_plot       = ch_diff_dispersion_plot
-    diff_md_plot               = ch_diff_md_plot
-    diff_rdata                 = ch_diff_rdata
-    diff_session_info          = ch_diff_session_info
-    diff_annotated             = ch_diff_annotated
+    diff_size_factors          = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.size_factors, ch_paramsets)
+    diff_dispersion_plot       = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.dispersion_plot, ch_paramsets)
+    diff_md_plot               = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.md_plot, ch_paramsets)
+    diff_rdata                 = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.rdata, ch_paramsets)
+    diff_session_info          = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.session_info, ch_paramsets)
+    diff_annotated             = prepareModuleOutput(CSVTK_JOIN.out.csv, ch_paramsets)
 
     // --- Functional: GSEA ---
-    gsea_report_tsv            = ch_gsea_report_tsv
-    gsea_report_html           = ch_gsea_report_html
-    gsea_index_html            = ch_gsea_index_html
-    gsea_heat_map_corr_plot    = ch_gsea_heat_map_corr_plot
-    gsea_ranked_gene_list      = ch_gsea_ranked_gene_list
-    gsea_gene_set_sizes        = ch_gsea_gene_set_sizes
-    gsea_histogram             = ch_gsea_histogram
-    gsea_heatmap               = ch_gsea_heatmap
-    gsea_pvalues_vs_nes_plot   = ch_gsea_pvalues_vs_nes_plot
-    gsea_ranked_list_corr      = ch_gsea_ranked_list_corr
-    gsea_butterfly_plot        = ch_gsea_butterfly_plot
-    gsea_gene_set_tsv          = ch_gsea_gene_set_tsv
-    gsea_gene_set_html         = ch_gsea_gene_set_html
-    gsea_gene_set_heatmap      = ch_gsea_gene_set_heatmap
-    gsea_gene_set_enplot       = ch_gsea_gene_set_enplot
-    gsea_gene_set_dist         = ch_gsea_gene_set_dist
-    gsea_snapshot              = ch_gsea_snapshot
-    gsea_archive               = ch_gsea_archive
-    gsea_rpt                   = ch_gsea_rpt
+    gsea_report_tsv            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_tsv, ch_paramsets)
+    gsea_report_html           = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_html, ch_paramsets)
+    gsea_index_html            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_index_html, ch_paramsets)
+    gsea_heat_map_corr_plot    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heat_map_corr_plot, ch_paramsets)
+    gsea_ranked_gene_list      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_gene_list, ch_paramsets)
+    gsea_gene_set_sizes        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_sizes, ch_paramsets)
+    gsea_histogram             = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_histogram, ch_paramsets)
+    gsea_heatmap               = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heatmap, ch_paramsets)
+    gsea_pvalues_vs_nes_plot   = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_pvalues_vs_nes_plot, ch_paramsets)
+    gsea_ranked_list_corr      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_list_corr, ch_paramsets)
+    gsea_butterfly_plot        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_butterfly_plot, ch_paramsets)
+    gsea_gene_set_tsv          = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_tsv, ch_paramsets)
+    gsea_gene_set_html         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_html, ch_paramsets)
+    gsea_gene_set_heatmap      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_heatmap, ch_paramsets)
+    gsea_gene_set_enplot       = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_enplot, ch_paramsets)
+    gsea_gene_set_dist         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_dist, ch_paramsets)
+    gsea_snapshot              = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_snapshot, ch_paramsets)
+    gsea_archive               = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_archive, ch_paramsets)
+    gsea_rpt                   = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_rpt, ch_paramsets)
 
     // --- Functional: gprofiler2 ---
-    gprofiler2_html            = ch_gprofiler2_html
-    gprofiler2_all_enrichment  = ch_gprofiler2_all_enrichment
-    gprofiler2_sub_enrichment  = ch_gprofiler2_sub_enrichment
-    gprofiler2_plot_png        = ch_gprofiler2_plot_png
-    gprofiler2_sub_plot        = ch_gprofiler2_sub_plot
-    gprofiler2_rds             = ch_gprofiler2_rds
-    gprofiler2_filtered_gmt    = ch_gprofiler2_filtered_gmt
+    gprofiler2_html            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_plot_html, ch_paramsets)
+    gprofiler2_all_enrichment  = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_all_enrich, ch_paramsets)
+    gprofiler2_sub_enrichment  = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_enrich, ch_paramsets)
+    gprofiler2_plot_png        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_artifacts, ch_paramsets)
+    gprofiler2_sub_plot        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_plot, ch_paramsets)
+    gprofiler2_rds             = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_rds, ch_paramsets)
+    gprofiler2_filtered_gmt    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_filtered_gmt, ch_paramsets)
 
     // --- Functional: decoupler ---
-    decoupler_estimate         = ch_decoupler_estimate
-    decoupler_pvals            = ch_decoupler_pvals
-    decoupler_png              = ch_decoupler_png
+    decoupler_estimate         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_estimate, ch_paramsets)
+    decoupler_pvals            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_pvals, ch_paramsets)
+    decoupler_png              = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_png, ch_paramsets)
 
     // --- Functional: common ---
-    functional_session_info    = ch_functional_session_info
+    functional_session_info    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.session_info, ch_paramsets)
 
     // --- Plotting ---
-    plot_exploratory           = ch_plots_exploratory
-    plot_volcanos              = ch_plots_volcanos
+    plot_exploratory           = prepareModuleOutput(
+        PLOT_EXPLORATORY.out.boxplots_png
+            .mix(PLOT_EXPLORATORY.out.densities_png)
+            .mix(PLOT_EXPLORATORY.out.pca2d_png)
+            .mix(PLOT_EXPLORATORY.out.pca3d_png)
+            .mix(PLOT_EXPLORATORY.out.mad_png)
+            .mix(PLOT_EXPLORATORY.out.dendro),
+        ch_paramsets
+    )
+    plot_volcanos              = prepareModuleOutput(PLOT_DIFFERENTIAL.out.volcanos_png, ch_paramsets)
 
     // --- ShinyNGS ---
     shinyngs_data              = SHINYNGS_APP.out.app.map { meta, data_rds, _app_r -> [meta, data_rds] }

--- a/workflows/differentialabundance.nf
+++ b/workflows/differentialabundance.nf
@@ -53,12 +53,6 @@ workflow DIFFERENTIALABUNDANCE {
     main:
 
     ch_versions      = channel.empty()
-    ch_preprocessing = channel.empty()
-    ch_differential  = channel.empty()
-    ch_functional    = channel.empty()
-    ch_plotting      = channel.empty()
-    ch_shinyngs      = channel.empty()
-    ch_report        = channel.empty()
 
     // ========================================================================
     // Handle input
@@ -178,9 +172,6 @@ workflow DIFFERENTIALABUNDANCE {
     UNTAR ( prepareModuleInput(ch_celfiles, 'preprocessing') )
     ch_untar_out = prepareModuleOutput(UNTAR.out.untar, ch_paramsets)
 
-    ch_preprocessing = ch_preprocessing
-        .mix(ch_untar_out.map { it -> ['affy_cel_files', it[0], it[1..-1]] })
-
     // Run affy
 
     ch_affy_input = prepareModuleInput(ch_input.affy_array.join(ch_untar_out), 'preprocessing')
@@ -198,11 +189,8 @@ workflow DIFFERENTIALABUNDANCE {
     ch_affy_norm = prepareModuleOutput(AFFY_JUSTRMA_NORM.out.expression, ch_paramsets)
     ch_affy_platform_features = prepareModuleOutput(AFFY_JUSTRMA_RAW.out.annotation, ch_paramsets)
 
-    ch_preprocessing = ch_preprocessing
-        .mix(ch_affy_raw.map { meta, file -> ['affy_raw_expression', meta, file] })
-        .mix(ch_affy_norm.map { meta, file -> ['affy_norm_expression', meta, file] })
-        .mix(ch_affy_platform_features.map { meta, file -> ['affy_annotation', meta, file] })
-        .mix(prepareModuleOutput(AFFY_JUSTRMA_RAW.out.rds, ch_paramsets).map { meta, file -> ['affy_raw_rds', meta, file] })
+    ch_affy_raw_rds = prepareModuleOutput(AFFY_JUSTRMA_RAW.out.rds, ch_paramsets)
+
     ch_versions = ch_versions
         .mix(AFFY_JUSTRMA_RAW.out.versions)
 
@@ -238,13 +226,10 @@ workflow DIFFERENTIALABUNDANCE {
             .mix(PROTEUS.out.norm_dist_plot)
         , ch_paramsets // here we keep contrast, as the plots are different across contrasts, and we can use it for output folder naming later
     )
-    ch_preprocessing = ch_preprocessing
-        .mix(ch_proteus_raw.map { meta, file -> ['proteus_raw', meta, file] })
-        .mix(ch_proteus_norm.map { meta, file -> ['proteus_norm', meta, file] })
-        .mix(ch_proteus_plots.map { meta, file -> ['proteus_plots', meta, file] })
-        .mix(prepareModuleOutput(PROTEUS.out.raw_rdata, ch_paramsets).map { meta, file -> ['proteus_raw_rdata', meta, file] })
-        .mix(prepareModuleOutput(PROTEUS.out.norm_rdata, ch_paramsets).map { meta, file -> ['proteus_norm_rdata', meta, file] })
-        .mix(prepareModuleOutput(PROTEUS.out.session_info, ch_paramsets).map { meta, file -> ['proteus_session_info', meta, file] })
+    ch_proteus_raw_rdata    = prepareModuleOutput(PROTEUS.out.raw_rdata, ch_paramsets)
+    ch_proteus_norm_rdata   = prepareModuleOutput(PROTEUS.out.norm_rdata, ch_paramsets)
+    ch_proteus_session_info = prepareModuleOutput(PROTEUS.out.session_info, ch_paramsets)
+
     ch_versions = ch_versions.mix(PROTEUS.out.versions)
 
     //
@@ -257,10 +242,8 @@ workflow DIFFERENTIALABUNDANCE {
     ch_soft_norm = prepareModuleOutput(GEOQUERY_GETGEO.out.expression, ch_paramsets)
     ch_soft_features = prepareModuleOutput(GEOQUERY_GETGEO.out.annotation, ch_paramsets)
 
-    ch_preprocessing = ch_preprocessing
-        .mix(ch_soft_norm.map { meta, file -> ['geo_expression', meta, file] })
-        .mix(ch_soft_features.map { meta, file -> ['geo_annotation', meta, file] })
-        .mix(prepareModuleOutput(GEOQUERY_GETGEO.out.rds, ch_paramsets).map { meta, file -> ['geo_rds', meta, file] })
+    ch_geo_rds = prepareModuleOutput(GEOQUERY_GETGEO.out.rds, ch_paramsets)
+
     ch_versions = ch_versions
         .mix(GEOQUERY_GETGEO.out.versions)
 
@@ -339,8 +322,6 @@ workflow DIFFERENTIALABUNDANCE {
     )
     ch_gtf_features = prepareModuleOutput(GTF_TO_TABLE.out.feature_annotation, ch_paramsets)
 
-    ch_preprocessing = ch_preprocessing
-        .mix(ch_gtf_features.map { meta, file -> ['gtf_annotation', meta, file] })
     ch_versions = ch_versions.mix(GTF_TO_TABLE.out.versions)
 
     // Extract features from matrix
@@ -525,16 +506,12 @@ workflow DIFFERENTIALABUNDANCE {
     ch_differential_norm = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.normalised_matrix, ch_paramsets, meta_keys_to_remove=['differential_method']) // meta, norm file
     ch_differential_varstab = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.variance_stabilised_matrix, ch_paramsets, meta_keys_to_remove=['differential_method']) // meta, varstab file
 
-    ch_differential = ch_differential
-        .mix(ch_differential_results.map { key, meta, file -> ['results', meta, file] })
-        .mix(ch_differential_results_filtered.map { key, meta, file -> ['results_filtered', meta, file] })
-        .mix(ch_differential_norm.map { meta, file -> ['normalised_matrix', meta, file] })
-        .mix(ch_differential_varstab.map { meta, file -> ['variance_stabilised_matrix', meta, file] })
-        .mix(prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.size_factors, ch_paramsets).map { meta, file -> ['size_factors', meta, file] })
-        .mix(prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.dispersion_plot, ch_paramsets).map { meta, file -> ['dispersion_plot', meta, file] })
-        .mix(prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.md_plot, ch_paramsets).map { meta, file -> ['md_plot', meta, file] })
-        .mix(prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.rdata, ch_paramsets).map { meta, file -> ['rdata', meta, file] })
-        .mix(prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.session_info, ch_paramsets).map { meta, file -> ['session_info', meta, file] })
+    ch_diff_size_factors    = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.size_factors, ch_paramsets)
+    ch_diff_dispersion_plot = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.dispersion_plot, ch_paramsets)
+    ch_diff_md_plot         = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.md_plot, ch_paramsets)
+    ch_diff_rdata           = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.rdata, ch_paramsets)
+    ch_diff_session_info    = prepareModuleOutput(ABUNDANCE_DIFFERENTIAL_FILTER.out.session_info, ch_paramsets)
+
     ch_versions = ch_versions
         .mix(ABUNDANCE_DIFFERENTIAL_FILTER.out.versions)
 
@@ -562,8 +539,8 @@ workflow DIFFERENTIALABUNDANCE {
         prepareModuleInput(ch_final_annotation_input, 'differential')
     )
 
-    ch_differential = ch_differential
-        .mix(prepareModuleOutput(CSVTK_JOIN.out.csv, ch_paramsets).map { meta, file -> ['annotated', meta, file] })
+    ch_diff_annotated = prepareModuleOutput(CSVTK_JOIN.out.csv, ch_paramsets)
+
     ch_versions = ch_versions
         .mix(CSVTK_JOIN.out.versions)
 
@@ -669,41 +646,37 @@ workflow DIFFERENTIALABUNDANCE {
     // by setting 'use_meta_key' to true. This will facilitate later on to join/combine channels.
     ch_functional_results = prepareModuleOutput(ch_functional_results, ch_paramsets, meta_keys_to_remove=['functional_method'], use_meta_key=true) // key, meta, [ functional results ]
 
-    ch_functional = ch_functional
-        // GSEA outputs
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_tsv, ch_paramsets).map { meta, ref, target -> ['gsea_report_tsv', meta, [ref, target]] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_html, ch_paramsets).map { meta, ref, target -> ['gsea_report_html', meta, [ref, target]] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_index_html, ch_paramsets).map { meta, file -> ['gsea_index_html', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heat_map_corr_plot, ch_paramsets).map { meta, file -> ['gsea_heat_map_corr_plot', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_gene_list, ch_paramsets).map { meta, file -> ['gsea_ranked_gene_list', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_sizes, ch_paramsets).map { meta, file -> ['gsea_gene_set_sizes', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_histogram, ch_paramsets).map { meta, file -> ['gsea_histogram', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heatmap, ch_paramsets).map { meta, file -> ['gsea_heatmap', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_pvalues_vs_nes_plot, ch_paramsets).map { meta, file -> ['gsea_pvalues_vs_nes_plot', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_list_corr, ch_paramsets).map { meta, file -> ['gsea_ranked_list_corr', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_butterfly_plot, ch_paramsets).map { meta, file -> ['gsea_butterfly_plot', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_tsv, ch_paramsets).map { meta, file -> ['gsea_gene_set_tsv', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_html, ch_paramsets).map { meta, file -> ['gsea_gene_set_html', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_heatmap, ch_paramsets).map { meta, file -> ['gsea_gene_set_heatmap', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_enplot, ch_paramsets).map { meta, file -> ['gsea_gene_set_enplot', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_dist, ch_paramsets).map { meta, file -> ['gsea_gene_set_dist', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_snapshot, ch_paramsets).map { meta, file -> ['gsea_snapshot', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_archive, ch_paramsets).map { meta, file -> ['gsea_archive', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_rpt, ch_paramsets).map { meta, file -> ['gsea_rpt', meta, file] })
-        // GPROFILER2 outputs
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_plot_html, ch_paramsets).map { meta, file -> ['gprofiler2_html', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_all_enrich, ch_paramsets).map { meta, file -> ['gprofiler2_all_enrichment', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_enrich, ch_paramsets).map { meta, file -> ['gprofiler2_sub_enrichment', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_artifacts, ch_paramsets).map { meta, file -> ['gprofiler2_plot_png', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_plot, ch_paramsets).map { meta, file -> ['gprofiler2_sub_plot', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_rds, ch_paramsets).map { meta, file -> ['gprofiler2_rds', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_filtered_gmt, ch_paramsets).map { meta, file -> ['gprofiler2_filtered_gmt', meta, file] })
-        // DECOUPLER outputs
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_estimate, ch_paramsets).map { meta, file -> ['decoupler_estimate', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_pvals, ch_paramsets).map { meta, file -> ['decoupler_pvals', meta, file] })
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_png, ch_paramsets).map { meta, file -> ['decoupler_png', meta, file] })
-        // common outputs
-        .mix(prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.session_info, ch_paramsets).map { meta, file -> ['session_info', meta, file] })
+    // Prepare functional outputs for individual emission
+    ch_gsea_report_tsv            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_tsv, ch_paramsets)
+    ch_gsea_report_html           = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_report_html, ch_paramsets)
+    ch_gsea_index_html            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_index_html, ch_paramsets)
+    ch_gsea_heat_map_corr_plot    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heat_map_corr_plot, ch_paramsets)
+    ch_gsea_ranked_gene_list      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_gene_list, ch_paramsets)
+    ch_gsea_gene_set_sizes        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_sizes, ch_paramsets)
+    ch_gsea_histogram             = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_histogram, ch_paramsets)
+    ch_gsea_heatmap               = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_heatmap, ch_paramsets)
+    ch_gsea_pvalues_vs_nes_plot   = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_pvalues_vs_nes_plot, ch_paramsets)
+    ch_gsea_ranked_list_corr      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_ranked_list_corr, ch_paramsets)
+    ch_gsea_butterfly_plot        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_butterfly_plot, ch_paramsets)
+    ch_gsea_gene_set_tsv          = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_tsv, ch_paramsets)
+    ch_gsea_gene_set_html         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_html, ch_paramsets)
+    ch_gsea_gene_set_heatmap      = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_heatmap, ch_paramsets)
+    ch_gsea_gene_set_enplot       = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_enplot, ch_paramsets)
+    ch_gsea_gene_set_dist         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_gene_set_dist, ch_paramsets)
+    ch_gsea_snapshot              = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_snapshot, ch_paramsets)
+    ch_gsea_archive               = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_archive, ch_paramsets)
+    ch_gsea_rpt                   = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gsea_rpt, ch_paramsets)
+    ch_gprofiler2_html            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_plot_html, ch_paramsets)
+    ch_gprofiler2_all_enrichment  = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_all_enrich, ch_paramsets)
+    ch_gprofiler2_sub_enrichment  = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_enrich, ch_paramsets)
+    ch_gprofiler2_plot_png        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_artifacts, ch_paramsets)
+    ch_gprofiler2_sub_plot        = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_sub_plot, ch_paramsets)
+    ch_gprofiler2_rds             = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_rds, ch_paramsets)
+    ch_gprofiler2_filtered_gmt    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.gprofiler2_filtered_gmt, ch_paramsets)
+    ch_decoupler_estimate         = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_estimate, ch_paramsets)
+    ch_decoupler_pvals            = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_dc_pvals, ch_paramsets)
+    ch_decoupler_png              = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.decoupler_png, ch_paramsets)
+    ch_functional_session_info    = prepareModuleOutput(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.session_info, ch_paramsets)
 
     ch_versions = ch_versions
         .mix(DIFFERENTIAL_FUNCTIONAL_ENRICHMENT.out.versions)
@@ -750,14 +723,15 @@ workflow DIFFERENTIALABUNDANCE {
         prepareModuleInput(ch_exploratory_input, 'exploratory')
     )
 
-    ch_plots_exploratory = PLOT_EXPLORATORY.out.boxplots_png
-        .mix(PLOT_EXPLORATORY.out.densities_png)
-        .mix(PLOT_EXPLORATORY.out.pca2d_png)
-        .mix(PLOT_EXPLORATORY.out.pca3d_png)
-        .mix(PLOT_EXPLORATORY.out.mad_png)
-        .mix(PLOT_EXPLORATORY.out.dendro)
-    ch_plotting = ch_plotting
-        .mix(prepareModuleOutput(ch_plots_exploratory, ch_paramsets).map { meta, file -> ['exploratory', meta, file] })
+    ch_plots_exploratory = prepareModuleOutput(
+        PLOT_EXPLORATORY.out.boxplots_png
+            .mix(PLOT_EXPLORATORY.out.densities_png)
+            .mix(PLOT_EXPLORATORY.out.pca2d_png)
+            .mix(PLOT_EXPLORATORY.out.pca3d_png)
+            .mix(PLOT_EXPLORATORY.out.mad_png)
+            .mix(PLOT_EXPLORATORY.out.dendro),
+        ch_paramsets
+    )
 
     // Plot differential analysis results
 
@@ -777,9 +751,7 @@ workflow DIFFERENTIALABUNDANCE {
         ch_plot_differential_input.samples_features_matrices
     )
 
-    ch_plots_differential = PLOT_DIFFERENTIAL.out.volcanos_png
-    ch_plotting = ch_plotting
-        .mix(prepareModuleOutput(PLOT_DIFFERENTIAL.out.volcanos_png, ch_paramsets).map { meta, file -> ['differential_volcanos', meta, file] })
+    ch_plots_volcanos = prepareModuleOutput(PLOT_DIFFERENTIAL.out.volcanos_png, ch_paramsets)
 
     // Gather software versions
 
@@ -888,10 +860,6 @@ workflow DIFFERENTIALABUNDANCE {
         ch_shinyngs_input.contrasts_and_differential,   // meta, contrast file, [ differential results ]
         ch_shinyngs_input.contrast_stats_assay
     )
-
-    ch_shinyngs = ch_shinyngs
-        .mix(SHINYNGS_APP.out.app.map { meta, data_rds, app_r -> ['shinyngs_data', meta, data_rds] })
-        .mix(SHINYNGS_APP.out.app.map { meta, data_rds, app_r -> ['shinyngs_app', meta, app_r] })
 
     ch_versions = ch_versions.mix(SHINYNGS_APP.out.versions)
 
@@ -1023,20 +991,96 @@ workflow DIFFERENTIALABUNDANCE {
         }
     MAKE_REPORT_BUNDLE( ch_bundle_input )
 
-    ch_report = ch_report
-        .mix(QUARTONOTEBOOK.out.html.map { meta, file -> ['report_html', meta, file] })
-        .mix(MAKE_REPORT_BUNDLE.out.zipped_archive.map { meta, file -> ['report_bundle', meta, file] })
-
     emit:
-    preprocessing = ch_preprocessing
-    differential  = ch_differential
-    functional    = ch_functional
-    plotting      = ch_plotting
-    shinyngs      = ch_shinyngs
-    report        = ch_report
-    versions      = ch_nfcore_versions
-        .map { file -> ['versions', [:], file] }
-        .mix(ch_collated_versions.map { file -> ['collated_versions', [:], file] })
+
+    // --- Preprocessing: Affy ---
+    affy_cel_files             = ch_untar_out
+    affy_raw_expression        = ch_affy_raw
+    affy_norm_expression       = ch_affy_norm
+    affy_annotation            = ch_affy_platform_features
+    affy_raw_rds               = ch_affy_raw_rds
+
+    // --- Preprocessing: Proteus ---
+    proteus_raw                = ch_proteus_raw
+    proteus_norm               = ch_proteus_norm
+    proteus_plots              = ch_proteus_plots
+    proteus_raw_rdata          = ch_proteus_raw_rdata
+    proteus_norm_rdata         = ch_proteus_norm_rdata
+    proteus_session_info       = ch_proteus_session_info
+
+    // --- Preprocessing: GEO ---
+    geo_expression             = ch_soft_norm
+    geo_annotation             = ch_soft_features
+    geo_rds                    = ch_geo_rds
+
+    // --- Preprocessing: GTF ---
+    gtf_annotation             = ch_gtf_features
+
+    // --- Differential ---
+    diff_results               = ch_differential_results
+    diff_results_filtered      = ch_differential_results_filtered
+    diff_normalised_matrix     = ch_differential_norm
+    diff_variance_stabilised   = ch_differential_varstab
+    diff_size_factors          = ch_diff_size_factors
+    diff_dispersion_plot       = ch_diff_dispersion_plot
+    diff_md_plot               = ch_diff_md_plot
+    diff_rdata                 = ch_diff_rdata
+    diff_session_info          = ch_diff_session_info
+    diff_annotated             = ch_diff_annotated
+
+    // --- Functional: GSEA ---
+    gsea_report_tsv            = ch_gsea_report_tsv
+    gsea_report_html           = ch_gsea_report_html
+    gsea_index_html            = ch_gsea_index_html
+    gsea_heat_map_corr_plot    = ch_gsea_heat_map_corr_plot
+    gsea_ranked_gene_list      = ch_gsea_ranked_gene_list
+    gsea_gene_set_sizes        = ch_gsea_gene_set_sizes
+    gsea_histogram             = ch_gsea_histogram
+    gsea_heatmap               = ch_gsea_heatmap
+    gsea_pvalues_vs_nes_plot   = ch_gsea_pvalues_vs_nes_plot
+    gsea_ranked_list_corr      = ch_gsea_ranked_list_corr
+    gsea_butterfly_plot        = ch_gsea_butterfly_plot
+    gsea_gene_set_tsv          = ch_gsea_gene_set_tsv
+    gsea_gene_set_html         = ch_gsea_gene_set_html
+    gsea_gene_set_heatmap      = ch_gsea_gene_set_heatmap
+    gsea_gene_set_enplot       = ch_gsea_gene_set_enplot
+    gsea_gene_set_dist         = ch_gsea_gene_set_dist
+    gsea_snapshot              = ch_gsea_snapshot
+    gsea_archive               = ch_gsea_archive
+    gsea_rpt                   = ch_gsea_rpt
+
+    // --- Functional: gprofiler2 ---
+    gprofiler2_html            = ch_gprofiler2_html
+    gprofiler2_all_enrichment  = ch_gprofiler2_all_enrichment
+    gprofiler2_sub_enrichment  = ch_gprofiler2_sub_enrichment
+    gprofiler2_plot_png        = ch_gprofiler2_plot_png
+    gprofiler2_sub_plot        = ch_gprofiler2_sub_plot
+    gprofiler2_rds             = ch_gprofiler2_rds
+    gprofiler2_filtered_gmt    = ch_gprofiler2_filtered_gmt
+
+    // --- Functional: decoupler ---
+    decoupler_estimate         = ch_decoupler_estimate
+    decoupler_pvals            = ch_decoupler_pvals
+    decoupler_png              = ch_decoupler_png
+
+    // --- Functional: common ---
+    functional_session_info    = ch_functional_session_info
+
+    // --- Plotting ---
+    plot_exploratory           = ch_plots_exploratory
+    plot_volcanos              = ch_plots_volcanos
+
+    // --- ShinyNGS ---
+    shinyngs_data              = SHINYNGS_APP.out.app.map { meta, data_rds, _app_r -> [meta, data_rds] }
+    shinyngs_app_file          = SHINYNGS_APP.out.app.map { meta, _data_rds, app_r -> [meta, app_r] }
+
+    // --- Report ---
+    report_html                = QUARTONOTEBOOK.out.html
+    report_bundle              = MAKE_REPORT_BUNDLE.out.zipped_archive
+
+    // --- Versions ---
+    nfcore_versions            = ch_nfcore_versions
+    collated_versions          = ch_collated_versions
 
 }
 


### PR DESCRIPTION
## Summary

- Refactors the inner workflow (`DIFFERENTIALABUNDANCE`) to emit each output as its own clean, typed channel (~62 individual emits) instead of mixing them into 7 broad category channels with name-tags
- Moves all name-tagging (`['name', meta, file]`) and category mixing logic into `main.nf`'s entry workflow, keeping publishing concerns in one place
- The `output {}` block is unchanged - it still consumes the same 7 category channels

This follows the principle established in nf-core/modules#11024: components should not mix disparate types into single channels or make assumptions about how consuming workflows will publish. The inner workflow now emits clean channels that are straightforward to consume, and will port more easily to future Nextflow enhancements (record types, etc.).

## Changes

- **`workflows/differentialabundance.nf`**: Removed `ch_preprocessing`, `ch_differential`, `ch_functional`, `ch_plotting`, `ch_shinyngs`, `ch_report` category channels and all `.mix()` chains. Each output is now emitted individually.
- **`main.nf`**: `NFCORE_DIFFERENTIALABUNDANCE` now passes through all ~62 individual channels. The entry workflow builds the 7 category channels with name-tagging in its `main:` block before publishing.

## Test plan

- [ ] CI tests pass (same test suite as PR #662)
- [ ] Output directory structure is unchanged (same `output {}` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)