### PR TITLE
Bump dream module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [[#689](https://github.com/nf-core/differentialabundance/pull/689)] - Normalize coefficient names in `variancepartition/dream` before building contrasts ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#684](https://github.com/nf-core/differentialabundance/pull/684)] - Fix intercept getting added automatically in `deseq2` ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst)).
 - [[#675](https://github.com/nf-core/differentialabundance/pull/675)] - Fix `study_type` rnaseq description for each method in quarto report ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst)).
 - [[#607](https://github.com/nf-core/differentialabundance/pull/607)] - Fix limma and dream modules to work with special characters and render report without a normalised matrix. Update all modules and subworkflows ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila), [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).

--- a/modules.json
+++ b/modules.json
@@ -127,7 +127,7 @@
                     },
                     "variancepartition/dream": {
                         "branch": "master",
-                        "git_sha": "48f50904ac6770bc6969a0618a2bf3598df1c823",
+                        "git_sha": "9ac1dfd203c4c6aa7a61b8ce3a6c6b09facf1265",
                         "installed_by": ["abundance_differential_filter", "modules"]
                     },
                     "zip": {

--- a/modules/nf-core/variancepartition/dream/templates/dream.R
+++ b/modules/nf-core/variancepartition/dream/templates/dream.R
@@ -286,7 +286,25 @@ fitmm <- eBayes(fitmm, proportion = opt\$proportion,
 
 # Display design matrix
 head(fitmm\$design, 3)
+cat("Raw coefficient names from dream():\n")
 print(colnames(fitmm\$design))
+
+# Normalize coefficient names consistently before building contrasts
+normalized_coef_names <- make.names(colnames(fitmm\$design))
+colnames(fitmm\$design) <- normalized_coef_names
+
+if (!is.null(colnames(fitmm\$coefficients))) {
+    colnames(fitmm\$coefficients) <- normalized_coef_names
+}
+if (!is.null(colnames(fitmm\$stdev.unscaled))) {
+    colnames(fitmm\$stdev.unscaled) <- normalized_coef_names
+}
+if (!is.null(fitmm\$cov.coefficients)) {
+    rownames(fitmm\$cov.coefficients) <- normalized_coef_names
+    colnames(fitmm\$cov.coefficients) <- normalized_coef_names
+}
+
+cat("Coefficient names used for contrasts:", paste(normalized_coef_names, collapse = ", "), "\n")
 
 # If contrast_string is provided, use that for makeContrast
 if (!is.null(opt\$contrast_string)) {
@@ -302,8 +320,7 @@ if (!is.null(opt\$contrast_string)) {
 if (is_valid_string(contrast_string)) {
     cat("Using contrast string:", contrast_string, "\n")
 
-    colnames(fitmm\$design) <- make.names(colnames(fitmm\$design))
-    contrast_matrix <- makeContrasts(contrast = contrast_string, levels = colnames(fitmm\$design))
+    contrast_matrix <- makeContrasts(contrast = contrast_string, levels = normalized_coef_names)
     fit2 <- contrasts.fit(fitmm, contrast_matrix)
     fit2 <- eBayes(fit2, proportion = opt\$proportion,
                   stdev.coef.lim = stdev_coef_lim_vals,


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->
## Update `variancepartition/dream` module with changes from https://github.com/nf-core/modules/pull/11137:
### Description
The `contrasts.fit()` matches the contrast rows against `colnames(fitmm$coefficients)`, and those coefficient names were not being normalized before (bug description in https://github.com/nf-core/differentialabundance/issues/688)

Now, the names are normalized consistently across `fitmm$design`, `fitmm$coefficients`, `fitmm$stdev.unscaled`, and `fitmm$cov.coefficients` before applying the contrast.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
