### PR TITLE
Add profiles for generic matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [[#692]](https://github.com/nf-core/differentialabundance/pull/692) - Add separate profile for generic, pre-scaled input matrices. ([@grst](https://github.com/grst), review by [@atrigila](https://github.com/atrigila) and [@pinin4fjords](https://github.com/pinin4fjords))
 - [[#683]](https://github.com/nf-core/differentialabundance/pull/683) - Improve documentation around `study_type` parameter. ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst)).
 - [[#649]](https://github.com/nf-core/differentialabundance/pull/649) - Add per-column filters to differentially expressed genes table. ([@antoniasaracco](https://github.com/antoniasaracco), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#613]](https://github.com/nf-core/differentialabundance/pull/613) - Add Box plots for differentially expressed genes. ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).

--- a/conf/profile/generic_matrix/generic_matrix.config
+++ b/conf/profile/generic_matrix/generic_matrix.config
@@ -3,7 +3,7 @@
     RNA-seq analysis profile (default: limma)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Sets parameters for a generic abundance matrix that is already on the appropriate scale (e.g. log-transformed)
-    to be analyzed with a linear model. 
+    to be analyzed with a linear model.
 
     Use as follows:
         nextflow run nf-core/differentialabundance -profile generic_matrix,<docker/singularity> --input <SAMPLESHEET> --matrix <MATRIX> --outdir <OUTDIR>

--- a/conf/profile/generic_matrix/generic_matrix.config
+++ b/conf/profile/generic_matrix/generic_matrix.config
@@ -1,0 +1,45 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq analysis profile (default: limma)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sets parameters for a generic abundance matrix that is already on the appropriate scale (e.g. log-transformed)
+    to be analyzed with a linear model. 
+
+    Use as follows:
+        nextflow run nf-core/differentialabundance -profile generic_matrix,<docker/singularity> --input <SAMPLESHEET> --matrix <MATRIX> --outdir <OUTDIR>
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    paramset_name = 'generic_matrix'
+
+    // Study
+    study_type = 'generic_matrix'
+    study_abundance_type = 'abundance'
+
+    // Features
+    features_type = 'feature'
+    features_id_col = 'feature_id'
+    features_name_col = 'feature_id'
+    features_metadata_cols = 'feature_id'
+    differential_feature_id_column = 'feature_id'
+
+    // Observations
+    observations_id_col = 'sample'
+    observations_name_col = 'sample'
+
+    // Differential analysis (limma)
+    differential_method = 'limma'
+    limma_use_voom = false
+
+    // Exploratory
+    exploratory_assay_names = 'raw'
+    exploratory_final_assay = 'raw'
+    exploratory_log2_assays = null
+
+    // Differential output columns
+    differential_file_suffix = '.limma.results.tsv'
+    differential_fc_column = 'logFC'
+    differential_pval_column = 'P.Value'
+    differential_qval_column = 'adj.P.Val'
+}

--- a/conf/profile/generic_matrix/generic_matrix_dream.config
+++ b/conf/profile/generic_matrix/generic_matrix_dream.config
@@ -1,0 +1,24 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RNA-seq DREAM analysis profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Inherits RNA-seq base settings from rnaseq.config and overrides with DREAM-specific
+    differential analysis parameters (mixed-effects models).
+----------------------------------------------------------------------------------------
+*/
+
+includeConfig 'generic_matrix.config'
+
+params {
+    paramset_name = 'generic_matrix_dream'
+
+    // Differential analysis (DREAM)
+    differential_method = 'dream'
+    dream_apply_voom = false
+
+    // Differential output columns
+    differential_file_suffix = '.dream.results.tsv'
+    differential_fc_column = 'logFC'
+    differential_pval_column = 'P.Value'
+    differential_qval_column = 'adj.P.Val'
+}

--- a/docs/output.md
+++ b/docs/output.md
@@ -69,9 +69,9 @@ Most plots are included in the HTML report (see above), but are also included in
     - `raw.matrix.tsv`: RMA background corrected matrix (Affy)
     - `normalised.matrix.tsv`: RMA background corrected and normalised intensities matrix (Affy)
   - `differential/`: Directory containing tables of differential statistics reported by differential modules such as DESeq2
-    - `[contrast_name].[deseq2|dream|limma].results.tsv`: Results of DESeq2 differential analyis (RNA-seq), DREAM differential analysis (RNA-seq for mixed linear models) OR Limma differential analysis (Affymetrix arrays, GEO studies, Maxquant proteomics studies)
-    - `[contrast_name].[deseq2|limma].results_filtered.tsv`: Results of DESeq2 differential analyis (RNA-seq) OR Limma differential analysis (Affymetrix arrays, GEO studies, Maxquant proteomics studies); filtered for differentially abundant entries
-    - `[contrast_name]_[deseq2|dream|limma].annotated.tsv`: Results of annotated DESeq2 differential analyis (RNA-seq), DREAM differential analysis (RNA-seq for mixed linear models) OR Limma differential analysis (Affymetrix arrays, GEO studies)
+    - `[contrast_name].[deseq2|dream|limma].results.tsv`: Results of DESeq2 differential analyis (RNA-seq), DREAM differential analysis (RNA-seq or generic matrix for mixed linear models) OR Limma differential analysis (Affymetrix arrays, GEO studies, Maxquant proteomics studies, generic matrix studies)
+    - `[contrast_name].[deseq2|limma].results_filtered.tsv`: Results of DESeq2 differential analyis (RNA-seq) OR Limma differential analysis (Affymetrix arrays, GEO studies, Maxquant proteomics studies, generic matrix studies); filtered for differentially abundant entries
+    - `[contrast_name]_[deseq2|dream|limma].annotated.tsv`: Results of annotated DESeq2 differential analyis (RNA-seq), DREAM differential analysis (RNA-seq or generic matrix for mixed linear models) OR Limma differential analysis (Affymetrix arrays, GEO studies, generic matrix studies)
   - `gsea/`: Directory containing tables of differential gene set analyis from GSEA (where enabled)
     - `[contrast]/[contrast].gsea_report_for_[condition].tsv`: A GSEA report table for each side of each contrast
   - `gprofiler2/`: Directory containing tables of differential gene set analyis from gprofiler2 (where enabled)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,6 +100,19 @@ So we **do not recommend** raw counts files such as `salmon.merged.gene_counts.t
 
 This is the proteinGroups.txt file produced by MaxQuant. It is a tab-separated matrix file with a column for every observation (plus additional columns for other types of measurements and information); each row contains these data for a set of proteins. The parameters `--observations_id_col` and `--features_id_col` define which of the associated fields should be matched in those inputs. The parameter `--proteus_measurecol_prefix` defines which prefix is used to extract those matrix columns which contain the measurements to be used. For example, the default `LFQ intensity ` will indicate that columns like LFQ intensity S1, LFQ intensity S2, LFQ intensity S3 etc. are used (one whitespace is automatically added if necessary).
 
+### Generic pre-scaled matrix
+
+```bash
+-profile generic_matrix
+--matrix '[path to matrix file].(csv|tsv)'
+```
+
+Use this profile when you already have an abundance matrix on the appropriate scale (e.g. log-transformed microarray intensities, log-CPM values, or any other pre-normalised data) and do not need RNA-seq-specific preprocessing such as DESeq2's VST/rlog or voom. The matrix is passed directly to Limma for differential analysis without any additional transformation.
+
+As with RNA-seq input, the matrix should have features as rows and observations as columns. Set `--observations_id_col` and `--features_id_col` to match the relevant identifier columns in the samplesheet and matrix, respectively. Feature annotations can be provided via `--features` or, if omitted, the workflow will fall back to using the matrix row identifiers directly.
+
+For mixed-effects models, use `-profile generic_matrix_dream` instead, which runs DREAM rather than Limma.
+
 ### Affymetrix microarrays
 
 ```bash
@@ -564,6 +577,22 @@ nextflow run nf-core/differentialabundance \
     --contrasts contrasts.yaml \
     --querygse GSE12345 \
     --outdir <OUTDIR>
+
+# Generic pre-scaled matrix (Limma)
+nextflow run nf-core/differentialabundance \
+    -profile generic_matrix,docker \
+    --input samplesheet.csv \
+    --contrasts contrasts.yaml \
+    --matrix my_matrix.tsv \
+    --outdir <OUTDIR>
+
+# Generic pre-scaled matrix (DREAM mixed-effects model)
+nextflow run nf-core/differentialabundance \
+    -profile generic_matrix_dream,docker \
+    --input samplesheet.csv \
+    --contrasts contrasts.yaml \
+    --matrix my_matrix.tsv \
+    --outdir <OUTDIR>
 ```
 
 Note that the pipeline will create the following files in your working directory:
@@ -704,6 +733,8 @@ These profiles configure the pipeline for specific study types, differential met
 
 - `maxquant` — MaxQuant proteomics with Limma
 - `soft` — GEO SOFT files with Limma
+- `generic_matrix` — Generic pre-scaled matrix with Limma
+- `generic_matrix_dream` — Generic pre-scaled matrix with DREAM (mixed-effects models)
 
 > [!WARNING]
 > Do not override `--differential_method` on the command line when using an analysis profile. Each profile also sets method-specific parameters (e.g. logFC and p-value column names). To change methods, use the appropriate profile (e.g. `-profile rnaseq_limma`).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -586,13 +586,6 @@ nextflow run nf-core/differentialabundance \
     --matrix my_matrix.tsv \
     --outdir <OUTDIR>
 
-# Generic pre-scaled matrix (DREAM mixed-effects model)
-nextflow run nf-core/differentialabundance \
-    -profile generic_matrix_dream,docker \
-    --input samplesheet.csv \
-    --contrasts contrasts.yaml \
-    --matrix my_matrix.tsv \
-    --outdir <OUTDIR>
 ```
 
 Note that the pipeline will create the following files in your working directory:

--- a/nextflow.config
+++ b/nextflow.config
@@ -377,6 +377,8 @@ profiles {
     affy_limma_gprofiler2     { includeConfig 'conf/profile/affy/affy_limma_gprofiler2.config'       }
     maxquant                  { includeConfig 'conf/profile/maxquant/maxquant.config'                }
     soft                      { includeConfig 'conf/profile/soft/soft.config'                        }
+    generic_matrix            { includeConfig 'conf/profile/generic_matrix/generic_matrix.config'    }
+    generic_matrix_dream      { includeConfig 'conf/profile/generic_matrix/generic_matrix_dream.config' }
 
     // Test profiles
     test              { includeConfig 'conf/test.config'              }


### PR DESCRIPTION
This PR adds profiles for generic, pre-transformed matrices (typically non-count data) that can be used with either limma or dream. 