### PR TITLE
Put variable of interest first in zero intercept constrasts for limma and dream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#702](https://github.com/nf-core/differentialabundance/pull/702)] - Update limma and dream modules to put variable of interest first in zero intercept constrasts ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila), [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#662](https://github.com/nf-core/differentialabundance/pull/662)] - Migrate to new workflow output format ([@suzannejin](https://github.com/suzannejin), review by [@pinin4fjords](https://github.com/pinin4fjords) and [@grst](https://github.com/grst)).
 - [[#686](https://github.com/nf-core/differentialabundance/pull/686)] - Improve `study_abundance_type` docs and schema description ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#681](https://github.com/nf-core/differentialabundance/pull/681)] - Remove the nextflow config default `--round_digits 4` parameter and change it for `-1` ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).

--- a/modules.json
+++ b/modules.json
@@ -77,7 +77,7 @@
                     },
                     "limma/differential": {
                         "branch": "master",
-                        "git_sha": "48f50904ac6770bc6969a0618a2bf3598df1c823",
+                        "git_sha": "72348f04b265fb310f87db1c8d12e2151cbabe14",
                         "installed_by": ["abundance_differential_filter", "modules"]
                     },
                     "propr/grea": {
@@ -127,7 +127,7 @@
                     },
                     "variancepartition/dream": {
                         "branch": "master",
-                        "git_sha": "9ac1dfd203c4c6aa7a61b8ce3a6c6b09facf1265",
+                        "git_sha": "72348f04b265fb310f87db1c8d12e2151cbabe14",
                         "installed_by": ["abundance_differential_filter", "modules"]
                     },
                     "zip": {

--- a/modules/nf-core/limma/differential/templates/limma_de.R
+++ b/modules/nf-core/limma/differential/templates/limma_de.R
@@ -313,16 +313,14 @@ if (!is.null(opt\$formula)) {
     cat("Column names after make.names():\n   ", paste(colnames(design), collapse = ", "), "\n")
 
 } else {
-    # Build the model formula with blocking variables first
-    model_vars <- c()
+    # Put the contrast variable first in zero-intercept designs so each
+    # contrast level is represented directly in the design matrix.
+    model_vars <- contrast_variable
 
     if (!is.null(opt\$blocking_variables)) {
         # Include blocking variables (including pairing variables if any)
         model_vars <- c(model_vars, blocking.vars)
     }
-
-    # Add the contrast variable at the end
-    model_vars <- c(model_vars, contrast_variable)
 
     # Construct the model formula
     model <- paste('~ 0 +', paste(model_vars, collapse = '+'))

--- a/modules/nf-core/variancepartition/dream/templates/dream.R
+++ b/modules/nf-core/variancepartition/dream/templates/dream.R
@@ -227,10 +227,10 @@ if (opt\$subset_to_contrast_samples) {
 if (is_valid_string(opt\$formula)) {
     form <- as.formula(opt\$formula)
 } else {
-    form <- '~ 0'
+    model_vars <- contrast_variable
 
     if (is_valid_string(opt\$blocking_variables)) {
-        form <- paste(form, paste(blocking.vars, collapse = ' + '), sep=' + ')
+        model_vars <- c(model_vars, blocking.vars)
     }
 
     # Make sure all the appropriate variables are factors
@@ -238,8 +238,9 @@ if (is_valid_string(opt\$formula)) {
         metadata[[v]] <- as.factor(make.names(metadata[[v]]))
     }
 
-    # Variable of interest goes last
-    form <- as.formula(paste(form, contrast_variable, sep = ' + '))
+    # Put the contrast variable first in zero-intercept designs so each
+    # contrast level is represented directly in the design matrix.
+    form <- as.formula(paste('~ 0 +', paste(model_vars, collapse = ' + ')))
 }
 print(form)
 


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->
Closes: https://github.com/nf-core/differentialabundance/issues/700
Bump dream and limma to integrate changes from https://github.com/nf-core/modules/pull/11189. 

> The "simple" contrasts depend on the model being a zero-intercept model that allows to directly reference all levels
> of the variable of interest as a separate coefficient. The catch is that this only works if the variable of interest is the first in the design formula. Otherwise the first level is omitted, to ensure that the design matrix remains full-rank.
>
> However, in both the rnaseq, dream and limma modules, the variable of interest is added last

Now, when building a zero-intercept model from the `contrasts` and `blocking_vars` parameters, the variable of interest is put first, directly after `~ 0 + `.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
