### PR TITLE
Drop misleading 'Error: null' from paramset validation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [[#718](https://github.com/nf-core/differentialabundance/issues/718)] - Drop misleading `Error: null` line printed before nf-schema validation errors on paramsheet validation failure ([@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#694](https://github.com/nf-core/differentialabundance/pull/694)] - Fix data flow for `generic_matrix` study type ([@grst](https://github.com/grst) and [@atrigila](https://github.com/atrigila), review by [@delfiterradas](https://github.com/delfiterradas)).
 - [[#689](https://github.com/nf-core/differentialabundance/pull/689)] - Normalize coefficient names in `variancepartition/dream` before building contrasts ([@delfiterradas](https://github.com/delfiterradas), review by [@grst](https://github.com/grst) and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#684](https://github.com/nf-core/differentialabundance/pull/684)] - Fix intercept getting added automatically in `deseq2` ([@atrigila](https://github.com/atrigila), review by [@grst](https://github.com/grst)).

--- a/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_differentialabundance_pipeline/main.nf
@@ -411,8 +411,8 @@ def validateConfigurations(configurations) {
             // Validate against schema
             validate(notnullparams, "${projectDir}/nextflow_schema.json")
         } catch (e) {
-            // if validation fails, print error message and exit
-            println("Validation failed for paramsheet row: ${paramset.paramset_name}. Error: ${e.message}")
+            // Surface the paramset name; nf-schema will then produce a detailed error.
+            log.error "Validation failed for paramsheet row: ${paramset.paramset_name}"
             validate(notnullparams, "${projectDir}/nextflow_schema.json")
         }
 


### PR DESCRIPTION
## Summary

- When pipeline validation failed (bad input path, malformed contrast file, etc.) the first line of output was `Validation failed for paramsheet row: <name>. Error: null` — misleading, since `e.message` on the underlying nf-schema exception is `null`.
- Replace the `println` with `log.error` and drop the bogus `Error: ${e.message}` suffix. The rethrown `validate()` call still triggers nf-schema's detailed error reporting underneath.
- CHANGELOG entry under "Fixed".

Closes #718

## Test plan

- [x] Reproduce on VM with `--input /tmp/missing-input.csv` — leading line is now `ERROR ~ Validation failed for paramsheet row: contrasts`, followed by nf-schema's validation detail. No `Error: null`.
- [x] `grep -rn 'Error: null' tests/ docs/` — no matches, no snapshot impact.