### PR TITLE
Fix observation table column width for columns with NA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [[#739](https://github.com/nf-core/differentialabundance/pull/739)] - Fix issue in quarto report data overview table in cases of columns with NAs ([@grst](https://github.com/grst), review by [@pinin4fjords](https://github.com/pinin4fjords)))
 - [[#738](https://github.com/nf-core/differentialabundance/pull/738)] - Fix conda failing tests before release ([@atrigila](https://github.com/atrigila), review by [@mashehu](https://github.com/mashehu)).
 - [[#729](https://github.com/nf-core/differentialabundance/pull/729)] - Skip nf-schema path-existence validation for `igenomes_base` so launches succeed when the default `s3://ngi-igenomes/igenomes/` bucket is not reachable from the user's environment ([@pinin4fjords](https://github.com/pinin4fjords), review by [@atrigila](https://github.com/atrigila)).
 - [[#725](https://github.com/nf-core/differentialabundance/issues/725)] - Tighten `report_file` schema pattern to explicitly model the comma-separated multi-report form and validate each segment's extension ([@pinin4fjords](https://github.com/pinin4fjords), review by [@atrigila](https://github.com/atrigila)).

--- a/assets/differentialabundance_report.qmd
+++ b/assets/differentialabundance_report.qmd
@@ -1365,7 +1365,7 @@ if (all(minimal_fetchngs_cols %in% colnames(observations))) {
     # Coerce per column rather than via apply (which flattens the frame to a
     # character matrix and silently drops any column containing an NA, because
     # max(nchar(NA)) is NA and `NA <= 20` is filtered out by `which`).
-        col_widths <- map_int(observations, \(x) max(nchar(as.character(x)), 0L, na.rm = TRUE))
+    col_widths <- map_int(observations, \(x) max(nchar(as.character(x)), 0L, na.rm = TRUE))
     additional_useful_cols <- names(col_widths)[col_widths <= 20]
 }
 

--- a/assets/differentialabundance_report.qmd
+++ b/assets/differentialabundance_report.qmd
@@ -1365,7 +1365,7 @@ if (all(minimal_fetchngs_cols %in% colnames(observations))) {
     # Coerce per column rather than via apply (which flattens the frame to a
     # character matrix and silently drops any column containing an NA, because
     # max(nchar(NA)) is NA and `NA <= 20` is filtered out by `which`).
-    col_widths <- map_int(observations, \(x) max(nchar(as.character(x)), na.rm = TRUE))
+        col_widths <- map_int(observations, \(x) max(nchar(as.character(x)), 0L, na.rm = TRUE))
     additional_useful_cols <- names(col_widths)[col_widths <= 20]
 }
 


### PR DESCRIPTION
This fixes an error "! Can't coerce from `-Inf` to an integer." in case of columns with NAs.

<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
