### PR TITLE
Disable implicit parallelism in dream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [[#743]](https://github.com/nf-core/differentialabundance/pull/743) - Update `variancepartition/dream` to disable implicit parallelism ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila), [@apeltzer](https://github.com/apeltzer), and [@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#734](https://github.com/nf-core/differentialabundance/pull/734)] - Update `variancepartition/dream` module and `abundance_differential_filter` subworkflow ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila) and [@apeltzer](https://github.com/apeltzer)).
 - [[#732](https://github.com/nf-core/differentialabundance/pull/732)] - Bump `nf-metro` pin to `>=0.7.2` and re-render the static and animated metro map images to pick up the upstream rowspan bbox-shrink fix ([@pinin4fjords](https://github.com/pinin4fjords)).
 - [[#731](https://github.com/nf-core/differentialabundance/pull/731)] - Embed the animated metro map SVG in the README with a static PNG fallback link, matching the nf-core/rnaseq README pattern ([@pinin4fjords](https://github.com/pinin4fjords)).

--- a/modules.json
+++ b/modules.json
@@ -128,7 +128,7 @@
                     },
                     "variancepartition/dream": {
                         "branch": "master",
-                        "git_sha": "77a353f5f9a174e9ddfc6aa4846d1e51ed0bdfd9",
+                        "git_sha": "87e0996ad70cb449019c505fd5f53f6594e26e4f",
                         "installed_by": ["abundance_differential_filter", "modules"]
                     },
                     "zip": {

--- a/modules/nf-core/variancepartition/dream/main.nf
+++ b/modules/nf-core/variancepartition/dream/main.nf
@@ -1,6 +1,6 @@
 process VARIANCEPARTITION_DREAM {
     tag "${meta.id}"
-    label 'process_single'
+    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/variancepartition/dream/templates/dream.R
+++ b/modules/nf-core/variancepartition/dream/templates/dream.R
@@ -82,6 +82,7 @@ opt <- list(
     contrast_string            = "$comparison",           # Full (complex) contrast expression comparison needed if using formula
     sample_id_col              = "sample",                # Column name for sample IDs
     threads                    = "$task.cpus",            # Number of threads for multithreading
+    blas_threads               = 1,                       # Number of threads for BLAS/OpenMP backends
     subset_to_contrast_samples = FALSE,                   # Whether to subset to contrast samples
     exclude_samples_col        = NULL,                    # Column for excluding samples
     exclude_samples_values     = NULL,                    # Values for excluding samples
@@ -116,6 +117,7 @@ keys <- c("formula", "contrast_string", "contrast_target", "contrast_variable", 
 opt[keys] <- lapply(opt[keys], nullify)
 
 opt\$threads      <- as.numeric(opt\$threads)
+opt\$blas_threads <- as.numeric(opt\$blas_threads)
 opt\$apply_voom   <- as.logical(opt\$apply_voom)
 opt\$proportion   <- as.numeric(opt\$proportion)
 opt\$trend        <- as.logical(opt\$trend)
@@ -134,6 +136,32 @@ if (!is.null(opt\$seed)) {
   RNGkind("L'Ecuyer-CMRG")
   set.seed(opt\$seed)
 }
+
+if (is.na(opt\$blas_threads) || opt\$blas_threads < 1) {
+  stop("'blas_threads' must be a positive integer")
+}
+opt\$blas_threads <- as.integer(opt\$blas_threads)
+
+configure_blas_threads <- function(threads) {
+  thread_env <- c(
+    OPENBLAS_NUM_THREADS = threads,
+    OMP_NUM_THREADS = threads,
+    MKL_NUM_THREADS = threads,
+    BLIS_NUM_THREADS = threads,
+    VECLIB_MAXIMUM_THREADS = threads,
+    NUMEXPR_NUM_THREADS = threads
+  )
+  do.call(Sys.setenv, as.list(thread_env))
+
+  if (requireNamespace("RhpcBLASctl", quietly = TRUE)) {
+    RhpcBLASctl::blas_set_num_threads(threads)
+    RhpcBLASctl::omp_set_num_threads(threads)
+  }
+
+  cat("Configured implicit BLAS/OpenMP threads to", threads, "\n")
+}
+
+configure_blas_threads(opt\$blas_threads)
 
 # Load metadata
 metadata <- read_delim_flexible(opt\$sample_file, header = TRUE, stringsAsFactors = TRUE)

--- a/modules/nf-core/variancepartition/dream/tests/main.nf.test.snap
+++ b/modules/nf-core/variancepartition/dream/tests/main.nf.test.snap
@@ -15,11 +15,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
-        "timestamp": "2025-12-23T18:57:51.598745459",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        }
+        },
+        "timestamp": "2025-12-23T18:57:51.598745459"
     },
     "RNAseq - Feature Counts - formula + comparison contrast string - interaction": {
         "content": [
@@ -37,11 +37,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
-        "timestamp": "2025-12-26T15:10:51.980662299",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        }
+        },
+        "timestamp": "2025-12-26T15:10:51.980662299"
     },
     "Mus musculus - contrasts - matrix - no formula": {
         "content": [
@@ -61,11 +61,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
-        "timestamp": "2025-12-16T15:52:08.047223666",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
-        }
+        },
+        "timestamp": "2025-12-16T15:52:08.047223666"
     },
     "Mus musculus - expression table - contrasts + blocking factors": {
         "content": [
@@ -130,11 +130,11 @@
                 ]
             }
         ],
-        "timestamp": "2025-12-16T19:59:57.947286403",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
-        }
+        },
+        "timestamp": "2025-12-16T19:59:57.947286403"
     },
     "Mus musculus - expression table - contrasts + blocking factors stub": {
         "content": [
@@ -199,11 +199,11 @@
                 ]
             }
         ],
-        "timestamp": "2025-11-10T16:18:37.294899756",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
-        }
+        },
+        "timestamp": "2025-11-10T16:18:37.294899756"
     },
     "Mus musculus - expression table - contrasts + formula + weighted comparison contrast string": {
         "content": [
@@ -221,11 +221,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
-        "timestamp": "2025-12-23T18:57:42.761838155",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        }
+        },
+        "timestamp": "2025-12-23T18:57:42.761838155"
     },
     "Mus musculus - expression table - contrasts + formula + comparison contrast string - no intercept stub": {
         "content": [
@@ -284,11 +284,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-01-13T15:35:07.121696674",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        }
+        },
+        "timestamp": "2026-01-13T15:35:07.121696674"
     },
     "RNAseq - Voom - Feature Counts - formula + comparison contrast string - interaction": {
         "content": [
@@ -316,11 +316,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
-        "timestamp": "2026-01-13T15:53:31.743589111",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        }
+        },
+        "timestamp": "2026-01-13T15:53:31.743589111"
     },
     "RNAseq - Feature Counts - formula + comparison contrast string - interaction with seed": {
         "content": [
@@ -379,11 +379,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-25T21:03:52.327619963",
         "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-05-07T19:32:24.587570625"
     },
     "Mus musculus - expression table - contrasts + formula + comparison contrast string": {
         "content": [
@@ -401,10 +401,10 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
-        "timestamp": "2025-12-26T15:11:01.472042429",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        }
+        },
+        "timestamp": "2025-12-26T15:11:01.472042429"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/differentialabundance pull request

Many thanks for contributing to nf-core/differentialabundance!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
-->
### Closes https://github.com/nf-core/differentialabundance/issues/742:

This PR integrates changes made in https://github.com/nf-core/modules/pull/11545, where `variancepartition/dream` was modified to remove implicit parallelism and assign more CPUs as discussed in: 

> https://github.com/nf-core/differentialabundance/issues/685#issue-4184455283
>
> There's two ways of parallelization in DE methods:
> 
> implicit paralellism via the underlying linear algebra libraries (applied during operations such as matrix multiplications)
> explicit paralellism via Bioc parallel.
> If both of them are active, this leads to a massive overbooking of threads, and therefore a high overhead cost, effectively slowing down the analysis.

For **resource usage metrics** using the different configurations that were tested **->** https://github.com/nf-core/modules/pull/11545#issuecomment-4567093621
## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/differentialabundance/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/differentialabundance _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
